### PR TITLE
refactor: normalize ion-content padding

### DIFF
--- a/src/app/components/epub/epub.html
+++ b/src/app/components/epub/epub.html
@@ -115,7 +115,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="epub-ion-content no-padding">
+<ion-content class="epub-ion-content no-padding" [scrollX]="false" [scrollY]="false">
   <div class="epub-content-wrapper" [class.mobile-mode-epub]="userSettingsService.isMobile()">
 
     <div class="toc-epub-container">

--- a/src/app/components/epub/epub.html
+++ b/src/app/components/epub/epub.html
@@ -115,7 +115,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="epub-ion-content">
+<ion-content class="epub-ion-content no-padding">
   <div class="epub-content-wrapper" [class.mobile-mode-epub]="userSettingsService.isMobile()">
 
     <div class="toc-epub-container">

--- a/src/app/components/epub/epub.scss
+++ b/src/app/components/epub/epub.scss
@@ -4,7 +4,6 @@
 ion-content.epub-ion-content::part(scroll) {
   display: flex;
   flex-flow: column nowrap;
-  padding: 0;
 }
 
 .epub-content-wrapper {

--- a/src/app/pages/about/about.scss
+++ b/src/app/pages/about/about.scss
@@ -1,21 +1,7 @@
-/* ATTN. Styles for elements in the markdown content must be defined in global.scss. */
+/* ATTN. Styles for elements in the markdown content must be globally defined in _markdown.scss to be applied. */
 
 .md_content {
     width: 100%;
     max-width: 800px;
-    padding: 1rem 1rem 4rem 1rem;
-}
-
-@media(max-width: 820px) {
-    .md_content {
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
-    }
-}
-
-@media(max-width: 600px) {
-    .md_content {
-        padding-left: 0;
-        padding-right: 0;
-    }
+    padding-bottom: 4rem;
 }

--- a/src/app/pages/collection-cover/collection-cover.html
+++ b/src/app/pages/collection-cover/collection-cover.html
@@ -12,13 +12,13 @@
   </div>
 </ion-content>
 
-<ion-content *ngIf="!hasDigitalEditionListChildren && !hasMDCover" class="collection-ion-content" [ngClass]="printMainContentClasses()">
+<ion-content *ngIf="!hasDigitalEditionListChildren && !hasMDCover" class="collection-ion-content" [ngClass]="printMainContentClasses()" [scrollX]="false" [scrollY]="false">
   <div class="scroll-content-container">
       <div class="tei teiContainer" [innerHTML]="text"></div>
   </div>
 </ion-content>
 
-<ion-content *ngIf="!hasDigitalEditionListChildren && hasMDCover" class="collection-ion-content" [ngClass]="printMainContentClasses()">
+<ion-content *ngIf="!hasDigitalEditionListChildren && hasMDCover" class="collection-ion-content" [ngClass]="printMainContentClasses()" [scrollX]="false" [scrollY]="false">
   <div class="cover-image-wrapper" [ngClass]="printMainContentClasses()">
     <img class="cover-image" [src]="image_src" [alt]="image_alt" loading="lazy">
   </div>

--- a/src/app/pages/collection-foreword/collection-foreword.html
+++ b/src/app/pages/collection-foreword/collection-foreword.html
@@ -17,7 +17,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="collection-ion-content" [ngClass]="printMainContentClasses()">
+<ion-content class="collection-ion-content" [ngClass]="printMainContentClasses()" [scrollX]="false" [scrollY]="false">
   <div class="scroll-content-container">
     <ng-container *ngIf="(text$ | async) as text; else loading">
       <div class="tei teiContainer"

--- a/src/app/pages/collection-introduction/collection-introduction.html
+++ b/src/app/pages/collection-introduction/collection-introduction.html
@@ -27,7 +27,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="collection-ion-content" [ngClass]="printMainContentClasses()">
+<ion-content class="collection-ion-content" [ngClass]="printMainContentClasses()" [scrollX]="false" [scrollY]="false">
   <div class="scroll-content-container">
 
     <!-- Tooltip wrapper -->

--- a/src/app/pages/collection-title/collection-title.html
+++ b/src/app/pages/collection-title/collection-title.html
@@ -17,7 +17,7 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="collection-ion-content" [ngClass]="printMainContentClasses()">
+<ion-content class="collection-ion-content" [ngClass]="printMainContentClasses()" [scrollX]="false" [scrollY]="false">
   <div *ngIf="hasDigitalEditionListChildren">
     <digital-edition-list-children [layoutType]="'auto'" [childrenPdfs]="childrenPdfs" [collectionID]="id"></digital-edition-list-children>
   </div>

--- a/src/app/pages/index/index-page.scss
+++ b/src/app/pages/index/index-page.scss
@@ -1,22 +1,5 @@
 ion-content {
     --padding-bottom: 5rem;
-    --padding-end: 2rem;
-    --padding-start: 2rem;
-    --padding-top: 2rem;
-
-    @media(max-width: 820px) {
-        --padding-bottom: 1.625rem;
-        --padding-end: 1.125rem;
-        --padding-start: 1.125rem;
-        --padding-top: 1.625rem;
-    }
-    
-    @media(max-width: 600px) {
-        --padding-bottom: 1.625rem;
-        --padding-end: 0.625rem;
-        --padding-start: 0.625rem;
-        --padding-top: 1.625rem;
-    }
 }
 
 h1.page-title {

--- a/src/theme/ionic/_ion-content.scss
+++ b/src/theme/ionic/_ion-content.scss
@@ -1,15 +1,20 @@
 ion-content {
     --background: var(--main-background-color);
-    --padding-bottom: 16px;
-    --padding-end: 16px;
-    --padding-start: 16px;
-    --padding-top: 16px;
+    --padding-bottom: 32px;
+    --padding-end: 32px;
+    --padding-start: 32px;
+    --padding-top: 32px;
 
     @media screen and (max-width: 820px) {
-        --padding-bottom: 10px;
+        --padding-bottom: 26px;
+        --padding-end: 18px;
+        --padding-start: 18px;
+        --padding-top: 26px;
+    }
+
+    @media screen and (max-width: 600px) {
         --padding-end: 10px;
         --padding-start: 10px;
-        --padding-top: 10px;
     }
 
     &.no-padding {
@@ -17,5 +22,21 @@ ion-content {
         --padding-end: 0;
         --padding-start: 0;
         --padding-top: 0;
+    }
+}
+
+ion-modal {
+    ion-content {
+        --padding-bottom: 16px;
+        --padding-end: 16px;
+        --padding-start: 16px;
+        --padding-top: 16px;
+    
+        @media screen and (max-width: 820px) {
+            --padding-bottom: 10px;
+            --padding-end: 10px;
+            --padding-start: 10px;
+            --padding-top: 10px;
+        }
     }
 }


### PR DESCRIPTION
The padding for the ion-content element has been normalized across components. Generally, components using ion-content no longer have to set the padding individually, except when making exceptions from the global CSS.