### PR TITLE
feature: improve semantic data

### DIFF
--- a/src/app/components/occurrences-accordion/occurrences-accordion.component.ts
+++ b/src/app/components/occurrences-accordion/occurrences-accordion.component.ts
@@ -25,18 +25,27 @@ export class OccurrencesAccordionComponent implements OnInit {
   groupedTexts: any[] = [];
   isLoading: boolean = true;
   occurrenceData: any[] = [];
-  showPublishedStatus: Number = 2;
+  showPublishedStatus: number = 2;
   simpleWorkMetadata: boolean = false;
 
   constructor(
     private commonFunctions: CommonFunctionsService,
     private semanticDataService: SemanticDataService
   ) {
-    this.showPublishedStatus = config.component?.occurrencesAccordion?.publishedStatus ?? 2;
     this.simpleWorkMetadata = config.useSimpleWorkMetadata ?? false;
   }
 
   ngOnInit() {
+    if (this.type === 'tag') {
+      this.showPublishedStatus = config.page?.index?.keywords?.publishedStatus ?? 2;
+    } else if (this.type === 'subject') {
+      this.showPublishedStatus = config.page?.index?.persons?.publishedStatus ?? 2;
+    } else if (this.type === 'location') {
+      this.showPublishedStatus = config.page?.index?.places?.publishedStatus ?? 2;
+    } else if (this.type === 'work') {
+      this.showPublishedStatus = config.page?.index?.works?.publishedStatus ?? 2;
+    }
+
     if (this.type === 'work' && this.simpleWorkMetadata) {
       this.isLoading = false;
     } else if (this.id && this.type) {

--- a/src/app/modals/semantic-data-object/semantic-data-object.modal.html
+++ b/src/app/modals/semantic-data-object/semantic-data-object.modal.html
@@ -20,7 +20,7 @@
   
         <div class="sd-header" *ngIf="data">
           <h2>
-            <span *ngIf="data?.details?.occupation && !hideTypeAndDescription" class="occupation">{{data.details.occupation}} – </span><span class="title" [innerHTML]="data?.details?.title"></span><span *ngIf="data?.details?.year_born_deceased" class="date" [innerHTML]="' ' + data.details.year_born_deceased"></span><span *ngIf="data?.details?.latitude && data?.details?.longitude" class="coordinates"> (<a [href]="'https://www.openstreetmap.org/?mlat=' + data.details.latitude + '&mlon=' + data.details.longitude" target="_blank"><ng-container i18n="@@Occurrences.latitude">lat.</ng-container> {{data.details.latitude}}, <ng-container i18n="@@Occurrences.longitude">long.</ng-container> {{data.details.longitude}}</a>)</span>
+            <span *ngIf="data?.details?.occupation && showOccupation" class="occupation">{{data.details.occupation}} – </span><span class="title" [innerHTML]="data?.details?.title"></span><span *ngIf="data?.details?.year_born_deceased || data?.details?.lived_between" class="date" [innerHTML]="data?.details?.lived_between ? ' (' + data.details.lived_between + ')' : ' ' + data.details.year_born_deceased"></span><span *ngIf="data?.details?.latitude && data?.details?.longitude" class="coordinates"> (<a [href]="'https://www.openstreetmap.org/?mlat=' + data.details.latitude + '&mlon=' + data.details.longitude" target="_blank"><ng-container i18n="@@Occurrences.latitude">lat.</ng-container> {{data.details.latitude}}, <ng-container i18n="@@Occurrences.longitude">long.</ng-container> {{data.details.longitude}}</a>)</span>
           </h2>
           <div class="media_image_wrapper" *ngIf="data?.media?.imageUrl">
             <img alt="occurrence image" [src]="data.media.imageUrl">
@@ -31,20 +31,20 @@
         </div>
   
         <div class="sd-box"
-            *ngIf="(data?.details?.city && !hideCityRegionCountry) || (data?.details?.region && !hideCityRegionCountry) || (data?.details?.country && !hideCityRegionCountry) || data?.details?.place_of_birth || (data?.details?.type && !hideTypeAndDescription) || data?.details?.source || data?.details?.publisher || data?.details?.published_year || data?.details?.isbn || (data?.details?.author_data?.length && data?.details?.author_data[0]) || data?.details?.journal || data?.details?.description || data?.articles?.length || data?.galleryOccurrences?.length"
+            *ngIf="(showCityRegionCountry && (data?.details?.city || data?.details?.region || data?.details?.country)) || data?.details?.place_of_birth || (data?.details?.type && showType) || data?.details?.source || data?.details?.publisher || data?.details?.published_year || data?.details?.isbn || (data?.details?.author_data?.length && data?.details?.author_data[0]) || data?.details?.journal || data?.details?.description || data?.articles?.length || data?.galleryOccurrences?.length || data?.details?.alias || data?.details?.previous_last_name"
         >
           <dl
-                *ngIf="(data?.details?.city && !hideCityRegionCountry) || (data?.details?.region && !hideCityRegionCountry) || (data?.details?.country && !hideCityRegionCountry) || data?.details?.place_of_birth || (data?.details?.type && !hideTypeAndDescription) || data?.details?.source || data?.details?.publisher || data?.details?.published_year || data?.details?.isbn || (data?.details?.author_data?.length && data?.details?.author_data[0]) || data?.details?.journal || (data?.details?.description && !hideTypeAndDescription) || data?.articles?.length"
+                *ngIf="(showCityRegionCountry && (data?.details?.city || data?.details?.region || data?.details?.country)) || data?.details?.place_of_birth || (data?.details?.type && showType) || data?.details?.source || data?.details?.publisher || data?.details?.published_year || data?.details?.isbn || (data?.details?.author_data?.length && data?.details?.author_data[0]) || data?.details?.journal || (data?.details?.description && showDescriptionLabel) || data?.articles?.length"
           >
-            <div *ngIf="data?.details?.city && !hideCityRegionCountry" class="city">
+            <div *ngIf="data?.details?.city && showCityRegionCountry" class="city">
               <dt i18n="@@Occurrences.city">Stad</dt>
               <dd>{{data.details.city}}</dd>
             </div>
-            <div *ngIf="data?.details?.region && !hideCityRegionCountry" class="region">
+            <div *ngIf="data?.details?.region && showCityRegionCountry" class="region">
               <dt i18n="@@Occurrences.region">Region</dt>
               <dd>{{data.details.region}}</dd>
             </div>
-            <div *ngIf="data?.details?.country && !hideCityRegionCountry" class="country">
+            <div *ngIf="data?.details?.country && showCityRegionCountry" class="country">
               <dt i18n="@@Occurrences.country">Land</dt>
               <dd>{{data.details.country}}</dd>
             </div>
@@ -52,7 +52,7 @@
               <dt i18n="@@Occurrences.place_of_birth">Ort</dt>
               <dd>{{data.details.place_of_birth}}</dd>
             </div>
-            <div *ngIf="data?.details?.type && !hideTypeAndDescription" class="type">
+            <div *ngIf="data?.details?.type && showType" class="type">
               <dt i18n="@@Occurrences.type">Typ</dt>
               <dd>{{data.details.type}}</dd>
             </div>
@@ -92,12 +92,13 @@
                 </ng-container>
             </dd>
             </div>
-            <div *ngIf="data?.details?.description && !hideTypeAndDescription" class="description">
+            <div *ngIf="data?.details?.description && showDescriptionLabel" class="description">
               <dt i18n="@@Occurrences.description">Beskrivning</dt>
               <dd>{{data.details.description}}</dd>
             </div>
           </dl>
-          <p *ngIf="data?.details?.description && hideTypeAndDescription" class="description">{{data.details.description}}</p>
+          <p *ngIf="showAliasAndPrevLastName && (data?.details?.alias || data?.details?.previous_last_name)" class="alias" [innerHTML]="data?.details?.alias ? (data?.details?.previous_last_name ? data?.details?.alias + ', ' + data?.details?.previous_last_name : data?.details?.alias) : data?.details?.previous_last_name"></p>
+          <p *ngIf="data?.details?.description && !showDescriptionLabel" class="description">{{data.details.description}}</p>
           <ion-button *ngIf="data?.galleryOccurrences?.length" class="custom-outline-button" fill="outline" i18n="@@TOC.MediaCollections" (click)="openGallery(data.galleryOccurrences[0])">Bildbank</ion-button>
         </div>
   

--- a/src/app/modals/semantic-data-object/semantic-data-object.modal.scss
+++ b/src/app/modals/semantic-data-object/semantic-data-object.modal.scss
@@ -44,6 +44,10 @@
 
         p {
             margin: 0;
+
+            + p {
+                margin-top: 0.25em;
+            }
         }
 
         dl {

--- a/src/app/modals/semantic-data-object/semantic-data-object.modal.ts
+++ b/src/app/modals/semantic-data-object/semantic-data-object.modal.ts
@@ -4,13 +4,12 @@ import { NavigationEnd, Router, RouterModule } from '@angular/router';
 import { IonicModule, ModalController } from '@ionic/angular';
 import { catchError, defaultIfEmpty, filter, forkJoin, map, Observable, of, Subject, Subscription, timeout } from 'rxjs';
 
-import { ComponentsModule } from 'src/app/components/components.module';
 import { OccurrencesAccordionComponent } from 'src/app/components/occurrences-accordion/occurrences-accordion.component';
 import { CommonFunctionsService } from 'src/app/services/common-functions.service';
 import { OccurrenceService } from 'src/app/services/occurence.service';
 import { SemanticDataService } from 'src/app/services/semantic-data.service';
 import { TooltipService } from 'src/app/services/tooltip.service';
-import { config } from "src/assets/config/config";
+import { config } from 'src/assets/config/config';
 
 
 @Component({
@@ -18,32 +17,44 @@ import { config } from "src/assets/config/config";
   selector: 'modal-semantic-data-object',
   templateUrl: 'semantic-data-object.modal.html',
   styleUrls: ['semantic-data-object.modal.scss'],
-  imports: [CommonModule, ComponentsModule, IonicModule, OccurrencesAccordionComponent, RouterModule]
+  imports: [CommonModule, IonicModule, OccurrencesAccordionComponent, RouterModule]
 })
 export class SemanticDataObjectModal implements OnInit {
   @Input() id: string = '';
   @Input() type: string = '';
 
-  hideTypeAndDescription = false;
-  hideCityRegionCountry = false;
   loadingErrorData$: Subject<boolean> = new Subject<boolean>();
   objectData$: Observable<any>;
   routerEventsSubscription: Subscription;
+  showAliasAndPrevLastName: boolean = true;
+  showArticleData: boolean = false;
+  showCityRegionCountry: boolean = false;
+  showDescriptionLabel: boolean = false;
+  showGalleryOccurrences: boolean = false;
+  showMediaData: boolean = false;
+  showOccupation: boolean = false;
   showOccurrences: boolean = true;
+  showType: boolean = false;
   simpleWorkMetadata: boolean = false;
 
   constructor(
-    private semanticDataService: SemanticDataService,
-    private modalCtrl: ModalController,
-    private tooltipService: TooltipService,
-    private occurrenceService: OccurrenceService,
     private commonFunctions: CommonFunctionsService,
-    public router: Router
+    private occurrenceService: OccurrenceService,
+    private modalCtrl: ModalController,
+    private router: Router,
+    private semanticDataService: SemanticDataService,
+    private tooltipService: TooltipService
   ) {
-    this.simpleWorkMetadata = config.useSimpleWorkMetadata ?? false;
-    this.hideTypeAndDescription = config.component?.occurrencesAccordion?.hideTypeAndDescription ?? false;
-    this.hideCityRegionCountry = config.component?.occurrencesAccordion?.hideCityRegionCountry ?? false;
+    this.showAliasAndPrevLastName = config.modal?.semanticDataObject?.showAliasAndPrevLastName ?? true;
+    this.showArticleData = config.modal?.semanticDataObject?.showArticleData ?? false;
+    this.showCityRegionCountry = config.modal?.semanticDataObject?.showCityRegionCountry ?? false;
+    this.showDescriptionLabel = config.modal?.semanticDataObject?.showDescriptionLabel ?? false;
+    this.showGalleryOccurrences = config.modal?.semanticDataObject?.showGalleryOccurrences ?? false;
+    this.showMediaData = config.modal?.semanticDataObject?.showMediaData ?? false;
+    this.showOccupation = config.modal?.semanticDataObject?.showOccupation ?? false;
     this.showOccurrences = config.modal?.semanticDataObject?.showOccurrences ?? true;
+    this.showType = config.modal?.semanticDataObject?.showType ?? false;
+    this.simpleWorkMetadata = config.useSimpleWorkMetadata ?? false;
   }
 
   ngOnInit() {
@@ -169,7 +180,7 @@ export class SemanticDataObjectModal implements OnInit {
   }
 
   private getSemanticDataObjectMediaData(type: string, id: string): Observable<any> {
-    return this.occurrenceService.getMediaData(type, id).pipe(
+    return (!this.showMediaData && of({})) || this.occurrenceService.getMediaData(type, id).pipe(
       timeout(20000),
       map((data: any) => {
         data.imageUrl = data.image_path;
@@ -182,7 +193,7 @@ export class SemanticDataObjectModal implements OnInit {
   }
 
   private getSemanticDataObjectArticleData(type: string, id: string): Observable<any> {
-    return this.occurrenceService.getArticleData(type, id).pipe(
+    return (!this.showArticleData && of({})) || this.occurrenceService.getArticleData(type, id).pipe(
       timeout(20000),
       catchError((error: any) => {
         return of({});
@@ -191,7 +202,7 @@ export class SemanticDataObjectModal implements OnInit {
   }
 
   private getSemanticDataObjectGalleryOccurrences(type: string, id: string): Observable<any> {
-    return this.occurrenceService.getGalleryOccurrences(type, id).pipe(
+    return (!this.showGalleryOccurrences && of({})) || this.occurrenceService.getGalleryOccurrences(type, id).pipe(
       timeout(20000),
       catchError((error: any) => {
         return of({});

--- a/src/app/pages/index/index-page.scss
+++ b/src/app/pages/index/index-page.scss
@@ -172,6 +172,11 @@ h1.page-title {
             --box-shadow: none;
             --color: var(--button-text-color, var(--text-color-on-primary-color-background));
             font-size: 1.125rem;
+            margin-right: 0;
+
+            @media screen and (max-width: 820px) {
+                margin-left: 0;
+            }
         }
     }
 }

--- a/src/app/pages/index/index-page.ts
+++ b/src/app/pages/index/index-page.ts
@@ -343,7 +343,7 @@ export class IndexPage implements OnInit {
     sortByName = sortByName.replace('ʽ', '').trim();
     if (indexType === 'persons') {
       sortByName = sortByName.replace(
-        /^(?:de la |de |von |van |af |d’ |d’|di |du |des |zu |auf |del |do |dos |da |das |e )/, ''
+        /^(?:de la |de |von der |van der |von |van |der |af |d’ |d’|di |du |des |zu |auf |del |do |dos |da |das |e )/, ''
       );
     }
     sortByName = sortByName.toLowerCase();
@@ -388,7 +388,10 @@ export class IndexPage implements OnInit {
             );
           } else {
             this.data = this.cachedData.filter(
-              item => item.name_for_list && (item.name_for_list as string).toLowerCase().includes(this.searchText.toLowerCase())
+              item => (
+                (item.name_for_list && (item.name_for_list as string).toLowerCase().includes(this.searchText.toLowerCase())) ||
+                (item.full_name && (item.full_name as string).toLowerCase().includes(this.searchText.toLowerCase()))
+              )
             );
           }
         }

--- a/src/app/services/tooltip.service.ts
+++ b/src/app/services/tooltip.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, SecurityContext } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
 import { DomSanitizer } from '@angular/platform-browser';
 import { catchError, map, Observable, of } from 'rxjs';
 
@@ -13,7 +12,6 @@ import { config } from "src/assets/config/config";
   providedIn: 'root',
 })
 export class TooltipService {
-  private API: string = '';
   private cachedTooltips: Record<string, any> = {
     'comments': new Map(),
     'footnotes': new Map(),
@@ -21,30 +19,16 @@ export class TooltipService {
     'places': new Map(),
     'works': new Map()
   };
-  private project: string = '';
   private maxTooltipCacheSize: number = 50;
   private simpleWorkMetadata: boolean = false;
 
   constructor(
-    private http: HttpClient,
-    private sanitizer: DomSanitizer,
     private commentService: CommentService,
+    private sanitizer: DomSanitizer,
     private semanticDataService: SemanticDataService,
     private userSettingsService: UserSettingsService
   ) {
-    this.API = config.app?.apiEndpoint ?? '';
-    this.project = config.app?.machineName ?? '';
     this.simpleWorkMetadata = config.useSimpleWorkMetadata ?? false;
-  }
-
-  getSingleSemanticObject(id: string, type: string): Observable<any> {
-    type = type === 'person' ? 'subject'
-      : type === 'place' ? 'location'
-      : type === 'keyword' ? 'tag'
-      : type;
-    return this.http.get(
-      `${this.API}/${this.project}/${type}/${id}`
-    );
   }
 
   getSemanticDataObjectTooltip(id: string, type: string, targetElem: HTMLElement): Observable<string> {
@@ -77,7 +61,7 @@ export class TooltipService {
         })
       );
     } else {
-      return this.getSingleSemanticObject(id, type).pipe(
+      return this.semanticDataService.getSingleSemanticDataObject(type, id).pipe(
         map((tooltip) => {
           let text = '';
           if (type === 'person') {
@@ -257,14 +241,7 @@ export class TooltipService {
       yearBorn !== 'null' &&
       yearDeceased !== 'null'
     ) {
-      yearBornDeceased =
-        '(' +
-        yearBorn +
-        bcIndicatorBorn +
-        '–' +
-        yearDeceased +
-        bcIndicatorDeceased +
-        ')';
+      yearBornDeceased = '(' + yearBorn + bcIndicatorBorn + '–' + yearDeceased + bcIndicatorDeceased + ')';
     } else if (yearBorn !== null && yearBorn !== 'null') {
       yearBornDeceased = '(* ' + yearBorn + bcIndicatorBorn + ')';
     } else if (yearDeceased !== null && yearDeceased !== 'null') {
@@ -330,8 +307,8 @@ export class TooltipService {
 
     // Set variable for determining if the tooltip should be placed above or below the trigger
     // rather than beside it.
-    let positionAboveOrBelowTrigger: Boolean = false;
-    let positionAbove: Boolean = false;
+    let positionAboveOrBelowTrigger: boolean = false;
+    let positionAbove: boolean = false;
 
     // Get rectangle which contains tooltiptrigger element. For trigger elements
     // spanning multiple lines tooltips are always placed above or below the trigger.
@@ -612,7 +589,7 @@ export class TooltipService {
     toolTipElem: HTMLElement,
     toolTipText: string,
     maxWidth = 0,
-    returnCompMaxWidth: Boolean = false
+    returnCompMaxWidth: boolean = false
   ) {
     // Create hidden div and make it into a copy of the tooltip div. Calculations are done on the hidden div.
     const hiddenDiv: HTMLElement = document.createElement('div');

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -9,7 +9,8 @@ export const config: Config = {
     machineName: "topelius",
     projectId: 10,
     apiEndpoint: "https://testa-vonwright.sls.fi:8000/digitaledition",
-    simpleApi: '',
+    simpleApi: "",
+    facsimileBase: "",
     i18n: {
       languages: [
         { code: "sv", label: "Svenska" },
@@ -18,7 +19,8 @@ export const config: Config = {
       defaultLanguage: "sv",
       enableLanguageChanges: true,
       multilingualCollectionTableOfContents: false,
-      multilingualReadingTextLanguages: []
+      multilingualReadingTextLanguages: [],
+      multilingualSemanticData: false
     },
     enableCollectionLegacyIDs: true,
     enableRouterLoadingBar: true
@@ -93,18 +95,21 @@ export const config: Config = {
       keywords: {
         maxFetchSize: 500,
         showFilter: true,
-        showPublishedStatus: 2
+        publishedStatus: 2
       },
       persons: {
         database: "elastic",
         maxFetchSize: 500,
-        showPublishedStatus: 2,
-        showFilter: true
+        showFilter: true,
+        publishedStatus: 2
       },
       places: {
         maxFetchSize: 500,
         showFilter: true,
-        showPublishedStatus: 2
+        publishedStatus: 2
+      },
+      works: {
+        publishedStatus: 2
       }
     },
     introduction: {
@@ -161,16 +166,22 @@ export const config: Config = {
     facsimileColumn: {
       imageQuality: 4,
       showFacsimileTitle: true
-    },
-    occurrencesAccordion: {
-      hideCityRegionCountry: true,
-      hideTypeAndDescription: true,
-      publishedStatus: 2
     }
   },
   modal: {
     fullscreenImageViewer: {
       imageQuality: 4
+    },
+    semanticDataObject: {
+      showAliasAndPrevLastName: false,
+      showArticleData: false,
+      showCityRegionCountry: false,
+      showDescriptionLabel: false,
+      showGalleryOccurrences: false,
+      showMediaData: false,
+      showOccupation: false,
+      showOccurrences: true,
+      showType: false
     }
   },
   urnResolverUrl: "https://urn.fi/",
@@ -524,18 +535,18 @@ export const config_soderholm: Config = {
       keywords: {
         maxFetchSize: 500,
         showFilter: true,
-        showPublishedStatus: 2
+        publishedStatus: 2
       },
       persons: {
         database: "elastic",
         maxFetchSize: 500,
-        showPublishedStatus: 2,
-        showFilter: true
+        showFilter: true,
+        publishedStatus: 2
       },
       places: {
         maxFetchSize: 500,
         showFilter: true,
-        showPublishedStatus: 2
+        publishedStatus: 2
       }
     },
     introduction: {
@@ -592,16 +603,14 @@ export const config_soderholm: Config = {
     facsimileColumn: {
       imageQuality: 2,
       showFacsimileTitle: false
-    },
-    occurrencesAccordion: {
-      hideCityRegionCountry: true,
-      hideTypeAndDescription: true,
-      publishedStatus: 2
     }
   },
   modal: {
     fullscreenImageViewer: {
       imageQuality: 2
+    },
+    semanticDataObject: {
+      showAliasAndPrevLastName: false
     }
   },
   urnResolverUrl: "https://urn.fi/",
@@ -1009,18 +1018,18 @@ export const config_vonWright: Config = {
       keywords: {
         maxFetchSize: 500,
         showFilter: true,
-        showPublishedStatus: 2
+        publishedStatus: 2
       },
       persons: {
         database: "elastic",
         maxFetchSize: 500,
-        showPublishedStatus: 2,
-        showFilter: true
+        showFilter: true,
+        publishedStatus: 2
       },
       places: {
         maxFetchSize: 500,
         showFilter: true,
-        showPublishedStatus: 2
+        publishedStatus: 2
       }
     },
     introduction: {
@@ -1077,16 +1086,14 @@ export const config_vonWright: Config = {
     facsimileColumn: {
       imageQuality: 4,
       showFacsimileTitle: false
-    },
-    occurrencesAccordion: {
-      hideCityRegionCountry: true,
-      hideTypeAndDescription: true,
-      publishedStatus: 2
     }
   },
   modal: {
     fullscreenImageViewer: {
       imageQuality: 4
+    },
+    semanticDataObject: {
+      showAliasAndPrevLastName: false
     }
   },
   urnResolverUrl: "https://urn.fi/",
@@ -1369,18 +1376,18 @@ export const config_granqvist: Config = {
       keywords: {
         maxFetchSize: 500,
         showFilter: true,
-        showPublishedStatus: 2
+        publishedStatus: 2
       },
       persons: {
         database: "elastic",
         maxFetchSize: 500,
-        showPublishedStatus: 2,
-        showFilter: true
+        showFilter: true,
+        publishedStatus: 2
       },
       places: {
         maxFetchSize: 500,
         showFilter: true,
-        showPublishedStatus: 2
+        publishedStatus: 2
       }
     },
     introduction: {
@@ -1437,16 +1444,18 @@ export const config_granqvist: Config = {
     facsimileColumn: {
       imageQuality: 1,
       showFacsimileTitle: false
-    },
-    occurrencesAccordion: {
-      hideCityRegionCountry: true,
-      hideTypeAndDescription: true,
-      publishedStatus: 2
     }
   },
   modal: {
     fullscreenImageViewer: {
       imageQuality: 1
+    },
+    semanticDataObject: {
+      showAliasAndPrevLastName: false,
+      showArticleData: true,
+      showCityRegionCountry: true,
+      showGalleryOccurrences: true,
+      showMediaData: true
     }
   },
   urnResolverUrl: "https://urn.fi/",
@@ -1622,7 +1631,8 @@ export const config_mechelin: Config = {
       defaultLanguage: "sv",
       enableLanguageChanges: true,
       multilingualCollectionTableOfContents: true,
-      multilingualReadingTextLanguages: ["sv", "fi"]
+      multilingualReadingTextLanguages: ["sv", "fi"],
+      multilingualSemanticData: true
     }
   },
   collections: {
@@ -1713,11 +1723,6 @@ export const config_mechelin: Config = {
     facsimileColumn: {
       imageQuality: 1,
       showFacsimileTitle: false
-    },
-    occurrencesAccordion: {
-      hideCityRegionCountry: true,
-      hideTypeAndDescription: true,
-      publishedStatus: 2
     }
   },
   modal: {


### PR DESCRIPTION
Improvements to the semantic data object modal and index page for persons.

Adds support for multilingual semantic data.

The semantic data object modal now has support for the following new data fields:
alias
lived_between (an alternative to year born and deceased)
previous_last_name

The index page search for persons when database type is other than 'elastic' now searches in two fields: name_for_list and full_name

BREAKING CHANGES:

Removed keys in config.ts:
component.occurrencesAccordion

Added keys in config.ts:
app.i18n.multilingualSemanticData (defaults to false, set to true to enable fetching semantic data of persons etc. in active locale language)
page.index.works.publishedStatus (defaults to 2)
modal.semanticDataObject.showAliasAndPrevLastName (defaults to true)
modal.semanticDataObject.showArticleData (defaults to false)
modal.semanticDataObject.showCityRegionCountry (defaults to false)
modal.semanticDataObject.showDescriptionLabel (defaults to false)
modal.semanticDataObject.showGalleryOccurrences (defaults to false)
modal.semanticDataObject.showMediaData (defaults to false)
modal.semanticDataObject.showOccupation (defaults to false)
modal.semanticDataObject.showType (defaults to false)

Renamed keys in config.ts:
page.index.keywords.showPublishedStatus --> page.index.keywords.publishedStatus
page.index.persons.showPublishedStatus --> page.index.persons.publishedStatus
page.index.places.showPublishedStatus --> page.index.places.publishedStatus