### PR TITLE
refactor: collection cover page

### DIFF
--- a/src/app/pages/collection-cover/collection-cover-routing.module.ts
+++ b/src/app/pages/collection-cover/collection-cover-routing.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+
 import { CollectionCoverPage } from './collection-cover';
+
 
 const routes: Routes = [
   {

--- a/src/app/pages/collection-cover/collection-cover.html
+++ b/src/app/pages/collection-cover/collection-cover.html
@@ -1,21 +1,20 @@
-<ion-header class="ion-no-border" *ngIf="!userSettingsService.isMobile()">
+<ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer [textItemID]="id" [parentPageType]="'page-cover'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'page-cover'" class="text-changer-desktop-mode"></text-changer>
 
   </ion-toolbar>
 </ion-header>
 
-<ion-content *ngIf="!hasMDCover" class="collection-ion-content" [ngClass]="printMainContentClasses()" [scrollX]="false" [scrollY]="false">
-  <div class="scroll-content-container">
-      <div class="tei teiContainer" [innerHTML]="text"></div>
-  </div>
+<ion-content class="collection-ion-content" [class.mobile-mode-content]="mobileMode" [scrollX]="false" [scrollY]="false">
+  <ng-container *ngIf="(coverData$ | async) as data; else loading">
+    <div class="cover-image-wrapper" [class.mobile-mode-content]="mobileMode">
+      <img class="cover-image" [src]="data.image_src" [alt]="data.image_alt" loading="lazy">
+    </div>
+  </ng-container>
+  <ng-template #loading>
+    <ion-spinner class="loading" name="crescent"></ion-spinner>
+  </ng-template>
 </ion-content>
 
-<ion-content *ngIf="hasMDCover" class="collection-ion-content" [ngClass]="printMainContentClasses()" [scrollX]="false" [scrollY]="false">
-  <div class="cover-image-wrapper" [ngClass]="printMainContentClasses()">
-    <img class="cover-image" [src]="image_src" [alt]="image_alt" loading="lazy">
-  </div>
-</ion-content>
-
-<text-changer *ngIf="userSettingsService.isMobile()" [textItemID]="id" [parentPageType]="'page-cover'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'page-cover'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/pages/collection-cover/collection-cover.scss
+++ b/src/app/pages/collection-cover/collection-cover.scss
@@ -4,9 +4,6 @@
 // Import general styles for the collection-ion-content class
 @import "src/theme/common/collection-ion-content.scss";
 
-// Import general styles for the scroll-content-container class
-@import "src/theme/common/scroll-content-container.scss";
-
 .cover-image-wrapper {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Covers can now be loaded only using markdown files to specify image URL and alt-texts.