### PR TITLE
refactor: collection title page

### DIFF
--- a/src/app/pages/collection-title/collection-title-routing.module.ts
+++ b/src/app/pages/collection-title/collection-title-routing.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+
 import { CollectionTitlePage } from './collection-title';
+
 
 const routes: Routes = [
   {

--- a/src/app/pages/collection-title/collection-title.html
+++ b/src/app/pages/collection-title/collection-title.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar class="secondary">
 
-    <text-changer slot="start" *ngIf="!userSettingsService.isMobile()" [textItemID]="id" [parentPageType]="'page-title'" class="text-changer-desktop-mode"></text-changer>
+    <text-changer slot="start" *ngIf="!mobileMode" [textItemID]="collectionID" [parentPageType]="'page-title'" class="text-changer-desktop-mode"></text-changer>
 
     <ion-buttons slot="end" class="secondary-toolbar-buttons-wrapper">
       <ion-button *ngIf="showURNButton" (click)="showReference()">
@@ -17,12 +17,15 @@
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="collection-ion-content" [ngClass]="printMainContentClasses()" [scrollX]="false" [scrollY]="false">
+<ion-content class="collection-ion-content" [class.mobile-mode-content]="mobileMode" [scrollX]="false" [scrollY]="false">
   <div class="scroll-content-container">
     <ng-container *ngIf="(text$ | async) as text; else loading">
-      <div class="tei teiContainer"
+      <div
+            [class.tei]="!titleFromMarkdownFolderId"
+            [class.teiContainer]="!titleFromMarkdownFolderId"
+            [class.markdown]="titleFromMarkdownFolderId"
+            [class.md_content]="titleFromMarkdownFolderId"
             [ngClass]="((readPopoverService.fontsize==0)?'xsmallFontSize':(readPopoverService.fontsize==1)?'smallFontSize':(readPopoverService.fontsize==2)?'mediumFontSize':(readPopoverService.fontsize==3)?'largeFontSize':'xlargeFontSize')"
-            [ngClass]="hasMDTitle ? 'md_content markdown' : ''"
             [innerHTML]="text"
       ></div>
     </ng-container>
@@ -32,4 +35,4 @@
   </div>
 </ion-content>
 
-<text-changer *ngIf="(userSettingsService.isMobile())" [textItemID]="id" [parentPageType]="'page-title'" class="text-changer-mobile-mode"></text-changer>
+<text-changer *ngIf="mobileMode" [textItemID]="collectionID" [parentPageType]="'page-title'" class="text-changer-mobile-mode"></text-changer>

--- a/src/app/pages/collection-title/collection-title.module.ts
+++ b/src/app/pages/collection-title/collection-title.module.ts
@@ -2,17 +2,18 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 
+import { TextChangerComponent } from 'src/app/components/text-changer/text-changer';
 import { CollectionTitlePage } from './collection-title';
 import { CollectionTitlePageRoutingModule } from './collection-title-routing.module';
-import { TextChangerComponent } from 'src/app/components/text-changer/text-changer';
+
 
 @NgModule({
   declarations: [
     CollectionTitlePage,
   ],
   imports: [
-    IonicModule,
     CommonModule,
+    IonicModule,
     TextChangerComponent,
     CollectionTitlePageRoutingModule
   ],

--- a/src/app/pages/collection-title/collection-title.scss
+++ b/src/app/pages/collection-title/collection-title.scss
@@ -6,20 +6,3 @@
 
 // Import general styles for the scroll-content-container class
 @import "src/theme/common/scroll-content-container.scss";
-
-// Styles for cover images on title page
-.tit_figure_graphic {
-  max-width: 50%;
-  display: block;
-  margin: 1rem auto 0 auto;
-}
-@media screen and (max-width: 600px) {
-  .tit_figure_graphic {
-    max-width: 70%;
-  }
-}
-@media screen and (max-width: 450px) {
-  .tit_figure_graphic {
-    max-width: 90%;
-  }
-}

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -27,6 +27,7 @@ export const config: Config = {
   },
   collections: {
     coversMarkdownFolderNumber: "08",
+    titlesMarkdownFolderNumber: "",
     enableMathJax: false,
     firstReadItem: {
       216: "216_20280", 219: "219_19443", 220: "220_20122",
@@ -376,7 +377,6 @@ export const config: Config = {
     ReadModeView: ["established", "comments", "facsimiles"]
   },
   defaultSelectedItem: "cover",
-  ProjectStaticMarkdownTitleFolder: "",
   HasCover: true,
   HasTitle: true,
   HasForeword: true,
@@ -405,6 +405,7 @@ export const config_soderholm: Config = {
   },
   collections: {
     coversMarkdownFolderNumber: "08",
+    titlesMarkdownFolderNumber: "",
     firstReadItem: {
       1084: "1084_77105", 1699: "1699_77946", 1700: "1700_78162",
       1701: "1701_78326", 1702: "1702_78404", 1703: "1703_78486",
@@ -742,7 +743,6 @@ export const config_soderholm: Config = {
     ReadModeView: ["facsimiles", "manuscripts"]
   },
   defaultSelectedItem: "cover",
-  ProjectStaticMarkdownTitleFolder: "05",
   HasCover: false,
   HasTitle: false,
   HasForeword: false,
@@ -771,6 +771,7 @@ export const config_vonWright: Config = {
   },
   collections: {
     coversMarkdownFolderNumber: "08",
+    titlesMarkdownFolderNumber: "",
     enableMathJax: true,
     firstReadItem: {
       146: "", 225: ""
@@ -1010,7 +1011,6 @@ export const config_vonWright: Config = {
     ReadModeView: ["established", "comments"]
   },
   defaultSelectedItem: "cover",
-  ProjectStaticMarkdownTitleFolder: "",
   HasCover: true,
   HasTitle: true,
   HasForeword: false,
@@ -1041,6 +1041,7 @@ export const config_granqvist: Config = {
   },
   collections: {
     coversMarkdownFolderNumber: "08",
+    titlesMarkdownFolderNumber: "09",
     firstReadItem: {
     },
     highlightSearchMatches: true,
@@ -1231,7 +1232,7 @@ export const config_granqvist: Config = {
     },
     title: {
       showURNButton: true,
-      showViewOptionsButton: true
+      showViewOptionsButton: false
     }
   },
   component: {
@@ -1361,15 +1362,14 @@ export const config_granqvist: Config = {
       MediaCollections: true,
       TagSearch: true,
       WorkSearch: false,
-      Books: true,
-      EPUB: false
+      Books: false,
+      EPUB: true
     }
   },
   defaults: {
     ReadModeView: ["facsimiles"]
   },
   defaultSelectedItem: "title",
-  ProjectStaticMarkdownTitleFolder: "09",
   HasCover: false,
   HasTitle: true,
   HasForeword: false,
@@ -1401,6 +1401,7 @@ export const config_mechelin: Config = {
   },
   collections: {
     coversMarkdownFolderNumber: "08",
+    titlesMarkdownFolderNumber: "",
     firstReadItem: {
       1: "1_1199"
     },
@@ -1587,7 +1588,6 @@ export const config_mechelin: Config = {
   defaults: {
       ReadModeView: ["established_sv", "established_fi", "manuscripts", "facsimiles"]
   },
-  ProjectStaticMarkdownTitleFolder: "",
   HasCover: false,
   HasTitle: false,
   HasForeword: false,


### PR DESCRIPTION
BREAKING CHANGES in config.ts:

Deleted key:
- ProjectStaticMarkdownTitleFolder

Added key:
- collections.titlesMarkdownFolderNumber (defaults to empty string, only used if title page contents should be read from markdown instead of from xml)