### PR TITLE
feature: add separate css variable for outline buttons

### DIFF
--- a/src/app/components/content-grid/content-grid.scss
+++ b/src/app/components/content-grid/content-grid.scss
@@ -19,7 +19,7 @@ ion-col {
     width: 100%;
 
     &:hover {
-      border-color: var(--button-background-color);
+      border-color: var(--outline-button-color);
       box-shadow: rgba(0, 0, 0, 0.2) 0px 3px 1px -2px, rgba(0, 0, 0, 0.2) 0px 2px 2px 0px, rgba(0, 0, 0, 0.2) 0px 1px 5px 0px;
     }
   }
@@ -30,7 +30,7 @@ ion-col {
   }
 
   h2 {
-    border-top: 1px solid var(--button-background-color);
+    border-top: 1px solid var(--outline-button-color);
     font-size: 1.125rem;
     line-height: 1.35;
     margin: 0.5rem 0 0 0;

--- a/src/app/components/date-histogram/date-histogram.scss
+++ b/src/app/components/date-histogram/date-histogram.scss
@@ -18,11 +18,11 @@
   }
 
   ion-datetime-button::part(native):hover {
-    border-color: var(--button-background-color);
+    border-color: var(--outline-button-color);
   }
 
   ion-datetime-button.date-active::part(native) {
-    color: var(--button-background-color) !important;
+    color: var(--outline-button-color) !important;
   }
 
   ion-datetime-button.blank::part(native) {

--- a/src/app/components/occurrences-accordion/occurrences-accordion.component.scss
+++ b/src/app/components/occurrences-accordion/occurrences-accordion.component.scss
@@ -79,9 +79,9 @@ ul {
 
 a.button-link {
     background-color: transparent;
-    border: 1px solid var(--button-background-color);
+    border: 1px solid var(--outline-button-color);
     border-radius: 2px;
-    color: var(--button-background-color);
+    color: var(--outline-button-color);
     display: block;
     font-size: 0.8125rem;
     letter-spacing: 0;

--- a/src/app/dialogs/modals/index-filter/index-filter.modal.scss
+++ b/src/app/dialogs/modals/index-filter/index-filter.modal.scss
@@ -16,7 +16,7 @@ ion-footer {
 
   ion-input {
     --background: #ffffff;
-    --highlight-color-valid: var(--button-background-color);
+    --highlight-color-valid: var(--outline-button-color);
     width: 100%;
   }
 }

--- a/src/app/dialogs/modals/semantic-data-object/semantic-data-object.modal.scss
+++ b/src/app/dialogs/modals/semantic-data-object/semantic-data-object.modal.scss
@@ -128,9 +128,9 @@
 
     a.button-link {
         background-color: transparent;
-        border: 1px solid var(--button-background-color);
+        border: 1px solid var(--outline-button-color);
         border-radius: 2px;
-        color: var(--button-background-color);
+        color: var(--outline-button-color);
         display: block;
         font-size: 0.8125rem;
         letter-spacing: 0;

--- a/src/app/dialogs/popovers/view-options/view-options.popover.scss
+++ b/src/app/dialogs/popovers/view-options/view-options.popover.scss
@@ -39,7 +39,7 @@ ion-button.close {
 
 ion-button.text-button {
 	--background: transparent;
-	--background-hover: var(--button-background-color);
+	--background-hover: var(--outline-button-color);
 	--background-hover-opacity: 0.2;
 	--box-shadow: none;
 	--color: #000;
@@ -54,7 +54,7 @@ ion-button.text-button::part(native) {
 	width: 3.25rem;
 }
 ion-button.text-button.selected-font-size {
-	--background: var(--button-background-color);
+	--background: var(--outline-button-color);
 	--color: #fff;
 }
 ion-button.text-xsmall {

--- a/src/app/pages/collection/text/collection-text.scss
+++ b/src/app/pages/collection/text/collection-text.scss
@@ -145,7 +145,7 @@ ion-fab.column-options {
 }
 
 ion-segment {
-  --background: var(--button-background-color);
+  --background: var(--outline-button-color);
   border-radius: 0;
   justify-content: center;
   margin: 0 auto;
@@ -158,7 +158,7 @@ ion-segment-button {
   font-size: 0.875rem;
 }
 ion-segment-button:not(.segment-button-checked) {
-  color: var(--button-text-color);
+  color: #fff;
 }
 
 // Adjust padding and background color of text and facsimile columns in mobile mode

--- a/src/app/pages/elastic-search/elastic-search.scss
+++ b/src/app/pages/elastic-search/elastic-search.scss
@@ -59,7 +59,7 @@ h1.page-title {
 
 .active-filters-row {
   align-items: flex-start;
-  border: 1px solid var(--button-background-color);
+  border: 1px solid var(--outline-button-color);
   border-radius: 3px;
   display: flex;
   font-size: 1rem;
@@ -152,7 +152,7 @@ h1.page-title {
       transition: border-color 0.4s;
 
       &:hover {
-        border-color: var(--button-background-color);
+        border-color: var(--outline-button-color);
       }
 
       h3 {
@@ -171,7 +171,7 @@ h1.page-title {
         width: 100%;
 
         &:hover {
-          color: var(--button-background-color);
+          color: var(--outline-button-color);
         }
 
         ion-icon {
@@ -213,18 +213,18 @@ h1.page-title {
       }
 
       ion-checkbox {
-        --border-color-checked: var(--button-background-color);
+        --border-color-checked: var(--outline-button-color);
         --checkbox-background: transparent;
-        --checkbox-background-checked: var(--button-background-color);
-        --checkmark-color: var(--button-text-color);
+        --checkbox-background-checked: var(--outline-button-color);
+        --checkmark-color: #fff;
         --transition: none;
         display: block;
         margin: 0;
 
         &:hover {
-          --border-color: var(--button-background-color);
+          --border-color: var(--outline-button-color);
           --checkbox-background: #fff;
-          color: var(--button-background-color);
+          color: var(--outline-button-color);
         }
       }
 
@@ -264,8 +264,8 @@ h1.page-title {
 
   ion-select.sort-select {
     --border-color: var(--elastic-search-filter-border-color);
-    --highlight-color-focused: var(--button-background-color);
-    --highlight-color-valid: var(--button-background-color);
+    --highlight-color-focused: var(--outline-button-color);
+    --highlight-color-valid: var(--outline-button-color);
     display: none;
     min-width: 130px;
     margin-left: auto;
@@ -273,7 +273,7 @@ h1.page-title {
     min-height: 3.125rem;
 
     &:hover {
-      --border-color: var(--button-background-color);
+      --border-color: var(--outline-button-color);
     }
 
     &.show-sort-options {

--- a/src/app/pages/index/index-page.scss
+++ b/src/app/pages/index/index-page.scss
@@ -169,9 +169,9 @@ h1.page-title {
         margin: 0.125rem 0 0 1.25rem;
 
         ion-fab-button {
-            --background: var(--button-background-color, var(--primary-color));
+            --background: var(--fab-button-primary-background-color, var(--primary-color));
             --box-shadow: none;
-            --color: var(--button-text-color, var(--text-color-on-primary-color-background));
+            --color: var(--fab-button-primary-icon-color, var(--text-color-on-primary-color-background));
             font-size: 1.125rem;
             margin-right: 0;
 

--- a/src/app/pages/media-collection/media-collection.scss
+++ b/src/app/pages/media-collection/media-collection.scss
@@ -35,8 +35,8 @@ a.back-link {
 
 .loading-overlay {
   align-items: center;
-  background-color: rgb(255, 255, 255);
-  border: 1px solid var(--button-background-color);
+  background-color: #fff;
+  border: 1px solid var(--outline-button-color);
   border-radius: 0.5rem;
   display: flex;
   height: 150px;
@@ -63,7 +63,7 @@ a.back-link {
   }
 
   p {
-    border: 1px solid var(--button-background-color);
+    border: 1px solid var(--outline-button-color);
     border-radius: 0.5em;
     font-size: 1rem;
     padding: 0.25em 0.375em;
@@ -88,14 +88,14 @@ a.back-link {
 
   ion-select {
     --border-color: var(--elastic-search-filter-border-color);
-    --highlight-color-focused: var(--button-background-color);
-    --highlight-color-valid: var(--button-background-color);
+    --highlight-color-focused: var(--outline-button-color);
+    --highlight-color-valid: var(--outline-button-color);
     flex-grow: 1;
     max-width: 30%;
     min-width: 240px;
 
     &:hover {
-      --border-color: var(--button-background-color);
+      --border-color: var(--outline-button-color);
     }
   }
 
@@ -144,7 +144,7 @@ ion-col {
     width: 100%;
 
     &:hover {
-      border-color: var(--button-background-color);
+      border-color: var(--outline-button-color);
       box-shadow: rgba(0, 0, 0, 0.2) 0px 3px 1px -2px, rgba(0, 0, 0, 0.2) 0px 2px 2px 0px, rgba(0, 0, 0, 0.2) 0px 1px 5px 0px;
     }
   }
@@ -163,7 +163,7 @@ ion-col {
   }
 
   figcaption {
-    border-top: 1px solid var(--button-background-color);
+    border-top: 1px solid var(--outline-button-color);
     margin: 0.5rem 0 0 0;
     padding: 1rem 0.25rem 0.5rem 0.25rem;
   }
@@ -186,7 +186,7 @@ ion-col {
     }
 
     p {
-      border: 1px solid var(--button-background-color);
+      border: 1px solid var(--outline-button-color);
       border-radius: 0.5em;
       font-size: 0.75rem;
       padding: 0.25em 0.375em;

--- a/src/theme/_variables.scss
+++ b/src/theme/_variables.scss
@@ -130,13 +130,13 @@
   // Buttons
   --button-background-color:                      var(--primary-color);
   --button-background-color-rgb:                  var(--primary-color-rgb);
-  --button-hover-background-color:                var(--button-background-color);
   --button-text-color:                            var(--text-color-on-primary-color-background);
   --button-clear-text-color:                      var(--primary-color);
   --fab-button-primary-background-color:          var(--primary-color);
   --fab-button-primary-icon-color:                var(--text-color-on-primary-color-background);
   --fab-button-secondary-background-color:      #e9e9e9;
   --fab-button-secondary-icon-color:            #000;
+  --outline-button-color:                         var(--primary-color); // must be dark enough to provide sufficient contrast on white and light to medium grey backgrounds, check the contrast especially against --main-background-color
 
   // Font stacks
   --font-stack-system:               -apple-system, BlinkMacSystemFont, "Segoe UI",

--- a/src/theme/ionic/_ion-alert.scss
+++ b/src/theme/ionic/_ion-alert.scss
@@ -1,8 +1,8 @@
 // Style for alert where a different variant, manuscript or facsimile text can be selected.
 ion-alert.custom-select-alert .alert-wrapper {
+    border-radius: var(--corner-border-radius);
     min-width: 300px;
     max-width: 500px;
-    border-radius: var(--corner-border-radius);
   
     .alert-title {
         font-size: 1.125rem;
@@ -21,7 +21,7 @@ ion-alert.custom-select-alert .alert-wrapper {
   
     button.alert-radio-button,
     button.alert-checkbox-button {
-        --color-checked: var(--button-background-color);
+        --color-checked: var(--outline-button-color);
         contain: content;
         font-size: 1rem;
         height: auto;
@@ -36,15 +36,15 @@ ion-alert.custom-select-alert .alert-wrapper {
         &[aria-checked="true"] {
             .alert-radio-icon,
             .alert-checkbox-icon {
-                border-color: var(--button-background-color);
+                border-color: var(--outline-button-color);
             }
             .alert-radio-inner,
             .alert-checkbox-icon {
-                background-color: var(--button-background-color);
+                background-color: var(--outline-button-color);
             }
             .alert-radio-label,
             .alert-checkbox-label {
-                color: var(--button-background-color);
+                color: var(--outline-button-color);
             }
         }
     }
@@ -53,12 +53,12 @@ ion-alert.custom-select-alert .alert-wrapper {
         align-items: center;
 
         .alert-button {
-            color: var(--button-background-color);
+            color: var(--outline-button-color);
         }
 
         .alert-button-highlighted {
-            color: var(--button-text-color);
             background-color: var(--button-background-color);
+            color: var(--button-text-color);
             height: 1.875rem;
         }
     }

--- a/src/theme/ionic/_ion-button.scss
+++ b/src/theme/ionic/_ion-button.scss
@@ -16,19 +16,20 @@ ion-button.button.circular-icon-button {
   --background: transparent;
   --background-hover: var(--button-background-color);
   --background-focused: var(--button-background-color);
-  --border-color: var(--button-background-color);
+  --border-color: var(--outline-button-color);
   --border-width: 1px;
-  --color: var(--button-background-color);
+  --color: var(--outline-button-color);
 }
 ion-button.button.circular-icon-button {
   --border-radius: 1.25rem;
   --padding-start: 0.25rem;
   --padding-end: 0.25rem;
-}
-ion-button.button.circular-icon-button ion-icon {
-  --color: var(--button-background-color);
-  --ionicon-stroke-width: 48px;
-  font-size: 1.25rem;
+
+  ion-icon {
+    --color: var(--outline-button-color);
+    --ionicon-stroke-width: 48px;
+    font-size: 1.25rem;
+  }
 }
 ion-button.button.close {
   --background-hover: transparent;

--- a/src/theme/ionic/_ion-popover.scss
+++ b/src/theme/ionic/_ion-popover.scss
@@ -1,8 +1,8 @@
 ion-popover.view-options-popover {
-    --min-width: 300px;
     --max-width: 100%;
-    --width: min-content;
+    --min-width: 300px;
     --offset-y: -30px;
+    --width: min-content;
 }
 
 /* Inline popover in page-text to add new view, additional styles defined inline in the template */
@@ -26,7 +26,7 @@ ion-popover.page-text-add-view-popover {
     ion-button.custom-outline-button {
         &:hover,
         &:focus {
-            --border-color: var(--button-background-color) !important;
+            --border-color: var(--outline-button-color) !important;
         }
     }
 }

--- a/src/theme/ionic/_ion-radio.scss
+++ b/src/theme/ionic/_ion-radio.scss
@@ -1,6 +1,6 @@
 ion-radio {
-    --color-checked: var(--button-background-color);
+    --color-checked: var(--outline-button-color);
 }
 ion-item.item-radio-checked {
-    --color: var(--button-background-color);
+    --color: var(--outline-button-color);
 }

--- a/src/theme/ionic/_ion-toggle.scss
+++ b/src/theme/ionic/_ion-toggle.scss
@@ -1,5 +1,5 @@
 ion-toggle {
+    --handle-background-checked: var(--outline-button-color);
     --track-background-checked: rgba(var(--button-background-color-rgb), 0.2);
-    --handle-background-checked: var(--button-background-color);
     font-size: 1rem;
 }


### PR DESCRIPTION
Add new css variable with default value:
--outline-button-color: var(--primary-color);

This variable is used for the color of outline buttons and other graphical elements where --button-background-color was previously used.

--outline-button-color must be dark enough to provide sufficient contrast on white and light to medium grey backgrounds, check the contrast especially against --main-background-color.

BREAKING CHANGES

The css variable --button-hover-background-color has been removed since it was not used.