### PR TITLE
feature: add default enabled view options to config

### DIFF
--- a/src/app/dialogs/popovers/view-options/view-options.popover.ts
+++ b/src/app/dialogs/popovers/view-options/view-options.popover.ts
@@ -31,17 +31,17 @@ export class ViewOptionsPopover implements OnDestroy, OnInit {
     'pageBreakOriginal': boolean,
     'pageBreakEdition': boolean
   };
-  show = {
-    'comments': false,
-    'personInfo': false,
-    'placeInfo': false,
-    'workInfo': false,
-    'changes': false,
-    'normalisations': false,
-    'abbreviations': false,
-    'paragraphNumbering': false,
-    'pageBreakOriginal': false,
-    'pageBreakEdition': false
+  show: Record<string, boolean> = {
+    comments: false,
+    personInfo: false,
+    placeInfo: false,
+    workInfo: false,
+    changes: false,
+    normalisations: false,
+    abbreviations: false,
+    paragraphNumbering: false,
+    pageBreakOriginal: false,
+    pageBreakEdition: false
   };
   textsize: Textsize = Textsize.Small;
   textsizeSubscription: Subscription | null = null;

--- a/src/app/services/view-options.service.ts
+++ b/src/app/services/view-options.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
+import { config } from '@config';
 import { Textsize } from '@models/textsize.model';
 
 
@@ -8,23 +9,30 @@ import { Textsize } from '@models/textsize.model';
   providedIn: 'root',
 })
 export class ViewOptionsService {
-  show = {
-    'comments': true,
-    'personInfo': false,
-    'abbreviations': false,
-    'placeInfo': false,
-    'workInfo': false,
-    'changes': false,
-    'normalisations': false,
-    'paragraphNumbering': false,
-    'pageBreakOriginal': false,
-    'pageBreakEdition': false
+  show: Record<string, boolean> = {
+    comments: false,
+    personInfo: false,
+    abbreviations: false,
+    placeInfo: false,
+    workInfo: false,
+    changes: false,
+    normalisations: false,
+    paragraphNumbering: false,
+    pageBreakOriginal: false,
+    pageBreakEdition: false
   };
 
   private epubAlertDismissed: boolean = false;
   private textsizeSubject: BehaviorSubject<Textsize> = new BehaviorSubject<Textsize>(Textsize.Small);
 
-  constructor() {}
+  constructor() {
+    const defaultViewOptions: string[] = config.page?.text?.defaultViewOptions ?? [];
+    Object.keys(this.show).forEach(key => {
+      if (defaultViewOptions.includes(key)) {
+        this.show[key] = true;
+      }
+    });
+  }
 
   getTextsize(): Observable<Textsize> {
     return this.textsizeSubject.asObservable();

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -245,6 +245,7 @@ export const config: Config = {
     },
     text: {
       defaultViews: ["established", "comments", "facsimiles"],
+      defaultViewOptions: ["comments"],
       showTextDownloadButton: true,
       showURNButton: true,
       showViewOptionsButton: true,
@@ -881,6 +882,7 @@ export const config_vonWright: Config = {
     },
     text: {
       defaultViews: ["established", "comments"],
+      defaultViewOptions: ["comments"],
       showURNButton: true,
       showViewOptionsButton: true,
       viewOptions: {
@@ -1410,6 +1412,7 @@ export const config_mechelin: Config = {
     },
     text: {
       defaultViews: ["established_sv", "established_fi", "manuscripts", "facsimiles"],
+      defaultViewOptions: ["comments", "personInfo", "abbreviations"],
       showTextDownloadButton: true,
       showURNButton: true,
       showViewOptionsButton: true,


### PR DESCRIPTION
The view options that should be enabled by default when entering a collection text page can now be set using config.ts.

New config key: page.text.defaultViewOptions
This is an array of strings that should contain the names of the view options that are enabled by default. Possible values are:
        comments
        personInfo
        placeInfo
        changes
        normalisations
        workInfo
        abbreviations
        paragraphNumbering
        pageBreakOriginal
        pageBreakEdition

These defaults will also be applied to the collection introduction page.