### PR TITLE
refactor (download texts modal): improve instructions

### DIFF
--- a/src/app/dialogs/modals/download-texts-modal/download-texts-modal.html
+++ b/src/app/dialogs/modals/download-texts-modal/download-texts-modal.html
@@ -138,28 +138,33 @@
         </div>
       </ng-container>
 
-      <ng-container *ngIf="downloadOptionsExist; else noOptions">
-        <div *ngIf="instructionsText || copyrightText" class="notice">
-          <p *ngIf="instructionsText" class="download-instructions" [innerHTML]="instructionsText"></p>
-          <p *ngIf="copyrightText && !copyrightURL" class="copyright-notice" [innerHTML]="copyrightText"></p>
-          <p *ngIf="copyrightText && copyrightURL" class="copyright-notice">
-            <a [href]="copyrightURL" target="_blank">
-              <span [innerHTML]="copyrightText"></span>
-              <ion-icon name="open-outline"
-                    [ngStyle]="{
-                      'font-size': '1.375rem',
-                      'padding-left': '0.125rem',
-                      'vertical-align': 'text-bottom'
-                    }"
-                    aria-label="Länken öppnas i ett nytt fönster"
-                    i18n-aria-label="@@BasicActions.OpenInNewWindow"
-              ></ion-icon>
-            </a>
-          </p>
-        </div>
+      <ng-container *ngIf="downloadOptionsExist; else noDownloads">
+        <ng-container *ngTemplateOutlet="showNotice; context: {$implicit: (instructionsText$ | async)}"/>
+
+        <ng-template #showNotice let-instructionsText>
+          <div *ngIf="copyrightText || instructionsText" class="notice">
+            <div *ngIf="instructionsText" class="markdown download-instructions" [innerHTML]="instructionsText"></div>
+            <p *ngIf="copyrightText && !copyrightURL" class="copyright-notice"><ng-container i18n="@@DownloadTexts.CopyrightNoticeLabel">Licens</ng-container>: <span [innerHTML]="copyrightText"></span></p>
+            <p *ngIf="copyrightText && copyrightURL" class="copyright-notice">
+              <ng-container i18n="@@DownloadTexts.CopyrightNoticeLabel">Licens</ng-container>: 
+              <a [href]="copyrightURL" target="_blank">
+                <span [innerHTML]="copyrightText"></span>
+                <ion-icon name="open-outline"
+                      [ngStyle]="{
+                        'font-size': '1.375rem',
+                        'padding-left': '0.125rem',
+                        'vertical-align': 'text-bottom'
+                      }"
+                      aria-label="Länken öppnas i ett nytt fönster"
+                      i18n-aria-label="@@BasicActions.OpenInNewWindow"
+                ></ion-icon>
+              </a>
+            </p>
+          </div>
+        </ng-template>
       </ng-container>
 
-      <ng-template #noOptions>
+      <ng-template #noDownloads>
         <p class="no-dl-options" i18n="@@DownloadTexts.NoDownloads">Inga texter tillgängliga för nedladdning eller utskrift.</p>
       </ng-template>
       

--- a/src/app/dialogs/modals/download-texts-modal/download-texts-modal.scss
+++ b/src/app/dialogs/modals/download-texts-modal/download-texts-modal.scss
@@ -26,11 +26,12 @@
 
 	p {
 		margin: 0;
-
-		+ p {
-			margin-top: 0.5rem;
-		}
 	}
+}
+
+.notice {
+	display: flex;
+	flex-flow: column nowrap;
 }
 
 ion-buttons {
@@ -64,4 +65,12 @@ ion-buttons {
 
 .no-dl-options {
 	margin: 0;
+}
+
+.markdown.download-instructions {
+	font-size: 1rem;
+
+	+ p {
+		margin-top: 0.5rem;
+	}
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -414,10 +414,9 @@
     "DownloadTexts": {
         "Download": "Download",
         "Title": "Download and print",
-        "Instructions": "Here you can download the texts in different formats. You can also open the texts in print-friendly format. The selected text will then open in a new window (you have to allow popup-windows from the web page).",
-        "InstructionsIntroduction": "Here you can download the introduction or open it in print-friendly format in a new window (you have to allow popup-windows from the web page).",
-        "CopyrightNotice": "Licence: CC BY-NC-ND 4.0",
-        "CopyrightNoticeIntroduction": "Licence: CC BY-NC-ND 4.0",
+        "CopyrightNoticeLabel": "License",
+        "CopyrightNotice": "CC BY-NC-ND 4.0",
+        "CopyrightNoticeIntroduction": "CC BY-NC-ND 4.0",
         "CopyrightURL": "https://creativecommons.org/licenses/by-nc-nd/4.0/deed.en",
         "CopyrightURLIntroduction": "https://creativecommons.org/licenses/by-nc-nd/4.0/deed.en",
         "Print": "Print",

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -414,10 +414,9 @@
     "DownloadTexts": {
         "Download": "Lataa",
         "Title": "Lataa ja tulosta",
-        "Instructions": "Tästä voit ladata tekstit eri tiedostomuodoissa. Voit myös avata tekstit uuteen ikkunaan tulostusta varten (sinun on sallittava popup-ikkunat verkkosivustolta).",
-        "InstructionsIntroduction": "Tästä voit ladata johdannon tai avata sen uuteen ikkunaan tulostusta varten (sinun on sallittava popup-ikkunat verkkosivustolta).",
-        "CopyrightNotice": "Lisenssi: CC BY-NC-ND 4.0",
-        "CopyrightNoticeIntroduction": "Lisenssi: CC BY-NC-ND 4.0",
+        "CopyrightNoticeLabel": "Lisenssi",
+        "CopyrightNotice": "CC BY-NC-ND 4.0",
+        "CopyrightNoticeIntroduction": "CC BY-NC-ND 4.0",
         "CopyrightURL": "https://creativecommons.org/licenses/by-nc-nd/4.0/deed.fi",
         "CopyrightURLIntroduction": "https://creativecommons.org/licenses/by-nc-nd/4.0/deed.fi",
         "Print": "Tulosta",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -414,10 +414,9 @@
     "DownloadTexts": {
         "Download": "Ladda ner",
         "Title": "Ladda ner och skriv ut",
-        "Instructions": "Här kan du ladda ner texterna i olika format. Du kan också öppna texterna i utskriftsvänligt format. Den valda texten öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).",
-        "InstructionsIntroduction": "Här kan du ladda ner inledningen eller öppna den i utskriftsvänligt format. Den öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).",
-        "CopyrightNotice": "Licens: CC BY-NC-ND 4.0",
-        "CopyrightNoticeIntroduction": "Licens: CC BY-NC-ND 4.0",
+        "CopyrightNoticeLabel": "Licens",
+        "CopyrightNotice": "CC BY-NC-ND 4.0",
+        "CopyrightNoticeIntroduction": "CC BY-NC-ND 4.0",
         "CopyrightURL": "https://creativecommons.org/licenses/by-nc-nd/4.0/deed.sv",
         "CopyrightURLIntroduction": "https://creativecommons.org/licenses/by-nc-nd/4.0/deed.sv",
         "Print": "Skriv ut",

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -111,13 +111,19 @@
     <unit id="DownloadTexts.CopyrightNotice">
       <segment state="initial">
         <source>Licens: CC BY-NC-ND 4.0</source>
-        <target>Licence: CC BY-NC-ND 4.0</target>
+        <target>CC BY-NC-ND 4.0</target>
       </segment>
     </unit>
     <unit id="DownloadTexts.CopyrightNoticeIntroduction">
       <segment state="initial">
         <source>Licens: CC BY-NC-ND 4.0</source>
-        <target>Licence: CC BY-NC-ND 4.0</target>
+        <target>CC BY-NC-ND 4.0</target>
+      </segment>
+    </unit>
+    <unit id="DownloadTexts.CopyrightNoticeLabel">
+      <segment state="initial">
+        <source>Licens</source>
+        <target>License</target>
       </segment>
     </unit>
     <unit id="DownloadTexts.CopyrightURL">
@@ -166,18 +172,6 @@
       <segment state="initial">
         <source>XML</source>
         <target>XML</target>
-      </segment>
-    </unit>
-    <unit id="DownloadTexts.Instructions">
-      <segment state="initial">
-        <source>Här kan du ladda ner texterna i olika format. Du kan också öppna texterna i utskriftsvänligt format. Den valda texten öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</source>
-        <target>Here you can download the texts in different formats. You can also open the texts in print-friendly format. The selected text will then open in a new window (you have to allow popup-windows from the web page).</target>
-      </segment>
-    </unit>
-    <unit id="DownloadTexts.InstructionsIntroduction">
-      <segment state="initial">
-        <source>Här kan du ladda ner inledningen eller öppna den i utskriftsvänligt format. Den öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</source>
-        <target>Here you can download the introduction or open it in print-friendly format in a new window (you have to allow popup-windows from the web page).</target>
       </segment>
     </unit>
     <unit id="DownloadTexts.MissingTextError">

--- a/src/locale/messages.fi.xlf
+++ b/src/locale/messages.fi.xlf
@@ -111,13 +111,19 @@
     <unit id="DownloadTexts.CopyrightNotice">
       <segment state="initial">
         <source>Licens: CC BY-NC-ND 4.0</source>
-        <target>Lisenssi: CC BY-NC-ND 4.0</target>
+        <target>CC BY-NC-ND 4.0</target>
       </segment>
     </unit>
     <unit id="DownloadTexts.CopyrightNoticeIntroduction">
       <segment state="initial">
         <source>Licens: CC BY-NC-ND 4.0</source>
-        <target>Lisenssi: CC BY-NC-ND 4.0</target>
+        <target>CC BY-NC-ND 4.0</target>
+      </segment>
+    </unit>
+    <unit id="DownloadTexts.CopyrightNoticeLabel">
+      <segment state="initial">
+        <source>Licens</source>
+        <target>Lisenssi</target>
       </segment>
     </unit>
     <unit id="DownloadTexts.CopyrightURL">
@@ -166,18 +172,6 @@
       <segment state="initial">
         <source>XML</source>
         <target>XML</target>
-      </segment>
-    </unit>
-    <unit id="DownloadTexts.Instructions">
-      <segment state="initial">
-        <source>Här kan du ladda ner texterna i olika format. Du kan också öppna texterna i utskriftsvänligt format. Den valda texten öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</source>
-        <target>Tästä voit ladata tekstit eri tiedostomuodoissa. Voit myös avata tekstit uuteen ikkunaan tulostusta varten (sinun on sallittava popup-ikkunat verkkosivustolta).</target>
-      </segment>
-    </unit>
-    <unit id="DownloadTexts.InstructionsIntroduction">
-      <segment state="initial">
-        <source>Här kan du ladda ner inledningen eller öppna den i utskriftsvänligt format. Den öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</source>
-        <target>Tästä voit ladata johdannon tai avata sen uuteen ikkunaan tulostusta varten (sinun on sallittava popup-ikkunat verkkosivustolta).</target>
       </segment>
     </unit>
     <unit id="DownloadTexts.MissingTextError">

--- a/src/locale/messages.sv.xlf
+++ b/src/locale/messages.sv.xlf
@@ -111,13 +111,19 @@
     <unit id="DownloadTexts.CopyrightNotice">
       <segment state="initial">
         <source>Licens: CC BY-NC-ND 4.0</source>
-        <target>Licens: CC BY-NC-ND 4.0</target>
+        <target>CC BY-NC-ND 4.0</target>
       </segment>
     </unit>
     <unit id="DownloadTexts.CopyrightNoticeIntroduction">
       <segment state="initial">
         <source>Licens: CC BY-NC-ND 4.0</source>
-        <target>Licens: CC BY-NC-ND 4.0</target>
+        <target>CC BY-NC-ND 4.0</target>
+      </segment>
+    </unit>
+    <unit id="DownloadTexts.CopyrightNoticeLabel">
+      <segment state="initial">
+        <source>Licens</source>
+        <target>Licens</target>
       </segment>
     </unit>
     <unit id="DownloadTexts.CopyrightURL">
@@ -166,18 +172,6 @@
       <segment state="initial">
         <source>XML</source>
         <target>XML</target>
-      </segment>
-    </unit>
-    <unit id="DownloadTexts.Instructions">
-      <segment state="initial">
-        <source>Här kan du ladda ner texterna i olika format. Du kan också öppna texterna i utskriftsvänligt format. Den valda texten öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</source>
-        <target>Här kan du ladda ner texterna i olika format. Du kan också öppna texterna i utskriftsvänligt format. Den valda texten öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</target>
-      </segment>
-    </unit>
-    <unit id="DownloadTexts.InstructionsIntroduction">
-      <segment state="initial">
-        <source>Här kan du ladda ner inledningen eller öppna den i utskriftsvänligt format. Den öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</source>
-        <target>Här kan du ladda ner inledningen eller öppna den i utskriftsvänligt format. Den öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</target>
       </segment>
     </unit>
     <unit id="DownloadTexts.MissingTextError">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -101,6 +101,11 @@
         <source>Licens: CC BY-NC-ND 4.0</source>
       </segment>
     </unit>
+    <unit id="DownloadTexts.CopyrightNoticeLabel">
+      <segment>
+        <source>Licens</source>
+      </segment>
+    </unit>
     <unit id="DownloadTexts.CopyrightURL">
       <segment>
         <source>https://creativecommons.org/licenses/by-nc-nd/4.0/deed.sv</source>
@@ -139,16 +144,6 @@
     <unit id="DownloadTexts.Format.XML">
       <segment>
         <source>XML</source>
-      </segment>
-    </unit>
-    <unit id="DownloadTexts.Instructions">
-      <segment>
-        <source>Här kan du ladda ner texterna i olika format. Du kan också öppna texterna i utskriftsvänligt format. Den valda texten öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</source>
-      </segment>
-    </unit>
-    <unit id="DownloadTexts.InstructionsIntroduction">
-      <segment>
-        <source>Här kan du ladda ner inledningen eller öppna den i utskriftsvänligt format. Den öppnas då i ett nytt fönster (du måste tillåta popup-fönster från webbplatsen).</source>
       </segment>
     </unit>
     <unit id="DownloadTexts.MissingTextError">

--- a/src/theme/_markdown.scss
+++ b/src/theme/_markdown.scss
@@ -1,180 +1,193 @@
 /* -- General styles for elements in markdown. -- */
 .markdown {
+  font-size: 1.125rem;
+
+  h1, h2, h3, h4, h5, h6 {
+    font-weight: 700;
+  }
+
+  h1, h2, h3, h4 {
+    margin-bottom: 0.5rem;
+  }
+
+  h1 {
+    font-size: 1.625rem;
+    margin-top: 2rem;
+    margin-bottom: 1.5rem;
+    text-transform: uppercase;
+  }
+
+  h1:first-child {
+    margin-top: 0;
+  }
+
+  h2 {
+    font-size: 1.4375rem;
+    margin-top: 1.8rem;
+  }
+
+  h3 {
+    font-size: 1.25rem;
+    margin-top: 1.5rem;
+  }
+
+  h2 + h3 {
+    margin-top: 1rem;
+  }
+
+  h4 {
     font-size: 1.125rem;
+    font-weight: normal;
+    font-style: italic;
+    margin-top: 1.25rem;
+  }
 
-    h1, h2, h3, h4, h5, h6 {
-        font-weight: 700;
-    }
+  p {
+    line-height: 1.625rem;
+    margin-bottom: 0.8rem;
+    margin-top: 0.8rem;
+  }
 
-    h1, h2, h3, h4 {
-        margin-bottom: 0.5rem;
-    }
+  hr {
+    background-color: rgba(0, 0, 0, 0.1);
+  }
 
+  td {
+    padding: 0.5em;
+    line-height: 1.4;
+    vertical-align: top;
+  }
+
+  figure {
+    margin: 1.75em 0;
+  }
+
+  img[src$="#align-left"] {
+    float: left;
+    margin: 0 1rem 1rem 0;
+  }
+
+  img[src$="#align-right"] {
+    float: right;
+    margin: 0 0 1rem 1rem;
+  }
+
+  img[src$="#align-center"] {
+    display: block;
+    margin: 1rem auto;
+  }
+
+  page-home {
     h1 {
-        font-size: 1.625rem;
-        margin-top: 2rem;
-        margin-bottom: 1.5rem;
-        text-transform: uppercase;
-    }
-
-    h1:first-child {
-        margin-top: 0;
+      text-transform: none;
     }
 
     h2 {
-        font-size: 1.4375rem;
-        margin-top: 1.8rem;
+      font-size: 1.625rem;
+      margin-top: 0;
     }
-
-    h3 {
-        font-size: 1.25rem;
-        margin-top: 1.5rem;
-    }
-
-    h2 + h3 {
-        margin-top: 1rem;
-    }
-
-    h4 {
-        font-size: 1.125rem;
-        font-weight: normal;
-        font-style: italic;
-        margin-top: 1.25rem;
-    }
-
-    p {
-        line-height: 1.625rem;
-        margin-bottom: 0.8rem;
-        margin-top: 0.8rem;
-    }
-
-    hr {
-        background-color: rgba(0, 0, 0, 0.1);
-    }
-
-    td {
-        padding: 0.5em;
-        line-height: 1.4;
-        vertical-align: top;
-    }
-
-    figure {
-        margin: 1.75em 0;
-    }
-
-    img[src$="#align-left"] {
-        float: left;
-        margin: 0 1rem 1rem 0;
-    }
-
-    img[src$="#align-right"] {
-        float: right;
-        margin: 0 0 1rem 1rem;
-    }
-
-    img[src$="#align-center"] {
-        display: block;
-        margin: 1rem auto;
-    }
-
-    page-home {
-        h1 {
-        text-transform: none;
-        }
-
-        h2 {
-        font-size: 1.625rem;
-        margin-top: 0;
-        }
-    }
+  }
 }
 
 /* --- Style block: Styles for the markdown content in the legend component. --- */
 .markdown.legend-markdown-content {
-    h2,
-    h2:first-child {
-        font-size: 1.25em;
-        font-variant: small-caps;
-        font-weight: normal;
-        margin: 0 0 0.5em;
-    }
-  
-    h3 {
-        font-size: 1.125em;
-        font-style: italic;
-        font-weight: bold;
-        margin: 2em 0 0.5em;
-    }
-  
-    h4 {
-        font-size: 1.125em;
-        font-style: italic;
-        margin: 2em 0 0.5em;
-    }
-  
-    h5 {
-        font-size: 1em;
-        font-weight: bold;
-        margin: 2em 0 0.5em;
-    }
-  
-    h6 {
-        font-size: 1em;
-        font-style: italic;
-        margin: 2em 0 0.5em;
-    }
-  
-    table {
-        margin: 1em 0;
-    }
-  
-    table th {
-      text-align: left;
-    }
-  
-    table td {
-        line-height: 1.25em;
-    }
-  
-    table.first-col-highlight {
-        td:first-child {
-            font-weight: bold;
-        }
-    }
-  
-    span.extVariantsTrigger {
-        cursor: default;
+  h2, h2:first-child {
+    font-size: 1.25em;
+    font-variant: small-caps;
+    font-weight: normal;
+    margin: 0 0 0.5em;
+  }
+
+  h3 {
+    font-size: 1.125em;
+    font-style: italic;
+    font-weight: bold;
+    margin: 2em 0 0.5em;
+  }
+
+  h4 {
+    font-size: 1.125em;
+    font-style: italic;
+    margin: 2em 0 0.5em;
+  }
+
+  h5 {
+    font-size: 1em;
+    font-weight: bold;
+    margin: 2em 0 0.5em;
+  }
+
+  h6 {
+    font-size: 1em;
+    font-style: italic;
+    margin: 2em 0 0.5em;
+  }
+
+  table {
+    margin: 1em 0;
+  }
+
+  table th {
+    text-align: left;
+  }
+
+  table td {
+    line-height: 1.25em;
+  }
+
+  table.first-col-highlight {
+    td:first-child {
+      font-weight: bold;
     }
   }
-  /* --- */
-  
-  /* --- Style block: Styles for the markdown content in the search pages. --- */
-  page-elastic-search,
-  page-persons,
-  page-places,
-  page-keywords,
-  page-works {
-    .markdown {
-      > p:first-child {
-        margin-top: 0;
-      }
-  
-      > p:last-child {
-          margin-bottom: 0;
-      }
+
+  span.extVariantsTrigger {
+    cursor: default;
+  }
+}
+/* --- */
+
+/* --- Style block: Styles for the markdown content in the search pages. --- */
+page-elastic-search,
+page-persons,
+page-places,
+page-keywords,
+page-works {
+  .markdown {
+    > p:first-child {
+      margin-top: 0;
+    }
+
+    > p:last-child {
+      margin-bottom: 0;
     }
   }
-  page-elastic-search .markdown {
-    ul {
-      list-style-type: disc;
-    }
-  
-    details summary {
-      cursor: pointer;
-      color: var(--default-link-color);
-    }
-    details summary::marker {
-      color: initial;
-    }
+}
+
+page-elastic-search .markdown {
+  ul {
+    list-style-type: disc;
   }
-  /* --- */
+
+  details summary {
+    cursor: pointer;
+    color: var(--default-link-color);
+  }
+
+  details summary::marker {
+    color: initial;
+  }
+}
+/* --- */
+
+/* --- Style block: Styles for the markdown content (instructions text) in download texts modal. --- */
+page-download-texts-modal .markdown {
+	*:first-child {
+		margin-top: 0;
+	}
+
+  *:last-child {
+		margin-bottom: 0;
+	}
+}
+/* --- */


### PR DESCRIPTION
The instructions text is now read from a markdown file in the backend. Markdown node id:s for the instruction texts:
12-06: instructions for collection texts
12-07: instructions for collection introductions