### PR TITLE
refactor: rename references to ’semantic data object’ in config to ’named entity’

### DIFF
--- a/src/app/components/occurrences-accordion/occurrences-accordion.component.ts
+++ b/src/app/components/occurrences-accordion/occurrences-accordion.component.ts
@@ -34,7 +34,7 @@ export class OccurrencesAccordionComponent implements OnInit {
     private namedEntityService: NamedEntityService,
     private tocService: CollectionTableOfContentsService
   ) {
-    this.simpleWorkMetadata = config.modal?.semanticDataObject?.useSimpleWorkMetadata ?? false;
+    this.simpleWorkMetadata = config.modal?.namedEntity?.useSimpleWorkMetadata ?? false;
   }
 
   ngOnInit() {

--- a/src/app/dialogs/modals/named-entity/named-entity.modal.ts
+++ b/src/app/dialogs/modals/named-entity/named-entity.modal.ts
@@ -42,16 +42,16 @@ export class NamedEntityModal implements OnInit {
     private router: Router,
     private tooltipService: TooltipService
   ) {
-    this.showAliasAndPrevLastName = config.modal?.semanticDataObject?.showAliasAndPrevLastName ?? true;
-    this.showArticleData = config.modal?.semanticDataObject?.showArticleData ?? false;
-    this.showCityRegionCountry = config.modal?.semanticDataObject?.showCityRegionCountry ?? false;
-    this.showDescriptionLabel = config.modal?.semanticDataObject?.showDescriptionLabel ?? false;
-    this.showGalleryOccurrences = config.modal?.semanticDataObject?.showGalleryOccurrences ?? false;
-    this.showMediaData = config.modal?.semanticDataObject?.showMediaData ?? false;
-    this.showOccupation = config.modal?.semanticDataObject?.showOccupation ?? false;
-    this.showOccurrences = config.modal?.semanticDataObject?.showOccurrences ?? true;
-    this.showType = config.modal?.semanticDataObject?.showType ?? false;
-    this.simpleWorkMetadata = config.modal?.semanticDataObject?.useSimpleWorkMetadata ?? false;
+    this.showAliasAndPrevLastName = config.modal?.namedEntity?.showAliasAndPrevLastName ?? true;
+    this.showArticleData = config.modal?.namedEntity?.showArticleData ?? false;
+    this.showCityRegionCountry = config.modal?.namedEntity?.showCityRegionCountry ?? false;
+    this.showDescriptionLabel = config.modal?.namedEntity?.showDescriptionLabel ?? false;
+    this.showGalleryOccurrences = config.modal?.namedEntity?.showGalleryOccurrences ?? false;
+    this.showMediaData = config.modal?.namedEntity?.showMediaData ?? false;
+    this.showOccupation = config.modal?.namedEntity?.showOccupation ?? false;
+    this.showOccurrences = config.modal?.namedEntity?.showOccurrences ?? true;
+    this.showType = config.modal?.namedEntity?.showType ?? false;
+    this.simpleWorkMetadata = config.modal?.namedEntity?.useSimpleWorkMetadata ?? false;
   }
 
   ngOnInit() {

--- a/src/app/services/named-entity.service.ts
+++ b/src/app/services/named-entity.service.ts
@@ -24,7 +24,7 @@ export class NamedEntityService {
     const apiBaseURL = config.app?.apiEndpoint ?? '';
     const projectName = config.app?.machineName ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
-    this.multilingual = config.app?.i18n?.multilingualSemanticData ?? false;
+    this.multilingual = config.app?.i18n?.multilingualNamedEntityData ?? false;
   }
 
   /**

--- a/src/app/services/tooltip.service.ts
+++ b/src/app/services/tooltip.service.ts
@@ -28,7 +28,7 @@ export class TooltipService {
     private platformService: PlatformService,
     private sanitizer: DomSanitizer
   ) {
-    this.simpleWorkMetadata = config.modal?.semanticDataObject?.useSimpleWorkMetadata ?? false;
+    this.simpleWorkMetadata = config.modal?.namedEntity?.useSimpleWorkMetadata ?? false;
   }
 
   getSemanticDataObjectTooltip(id: string, type: string, targetElem: HTMLElement): Observable<string> {

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -18,7 +18,7 @@ export const config: Config = {
       defaultLanguage: "sv",
       multilingualCollectionTableOfContents: false,
       multilingualReadingTextLanguages: [],
-      multilingualSemanticData: false
+      multilingualNamedEntityData: false
     },
     enableRouterLoadingBar: true
   },
@@ -374,7 +374,7 @@ export const config: Config = {
     referenceData: {
       URNResolverURL: "https://urn.fi/",
     },
-    semanticDataObject: {
+    namedEntity: {
       showAliasAndPrevLastName: false,
       showArticleData: false,
       showCityRegionCountry: false,
@@ -742,7 +742,7 @@ export const config_soderholm: Config = {
     referenceData: {
       URNResolverURL: "https://urn.fi/",
     },
-    semanticDataObject: {
+    namedEntity: {
       showAliasAndPrevLastName: false,
       useSimpleWorkMetadata: false
     }
@@ -997,7 +997,7 @@ export const config_vonWright: Config = {
     referenceData: {
       URNResolverURL: "https://urn.fi/",
     },
-    semanticDataObject: {
+    namedEntity: {
       showAliasAndPrevLastName: false,
       useSimpleWorkMetadata: false
     }
@@ -1318,7 +1318,7 @@ export const config_granqvist: Config = {
     referenceData: {
       URNResolverURL: "https://urn.fi/",
     },
-    semanticDataObject: {
+    namedEntity: {
       showAliasAndPrevLastName: false,
       showArticleData: true,
       showCityRegionCountry: true,
@@ -1347,7 +1347,7 @@ export const config_mechelin: Config = {
       defaultLanguage: "sv",
       multilingualCollectionTableOfContents: true,
       multilingualReadingTextLanguages: ["sv", "fi"],
-      multilingualSemanticData: true
+      multilingualNamedEntityData: true
     }
   },
   collections: {
@@ -1529,7 +1529,7 @@ export const config_mechelin: Config = {
     referenceData: {
       URNResolverURL: "https://urn.fi/",
     },
-    semanticDataObject: {
+    namedEntity: {
       showOccurrences: false,
       useSimpleWorkMetadata: false
     }


### PR DESCRIPTION
**BREAKING CHANGES**

_Renamed keys in config.ts:_

app.i18n.multilingualSemanticData
--> app.i18n.multilingualNamedEntityData

modal.semanticDataObject
--> modal.namedEntity