### PR TITLE
refactor: rename selector for the download texts modal

### DIFF
--- a/src/app/dialogs/modals/download-texts/download-texts.modal.ts
+++ b/src/app/dialogs/modals/download-texts/download-texts.modal.ts
@@ -20,7 +20,7 @@ import { concatenateNames } from '@utility-functions';
 
 @Component({
   standalone: true,
-  selector: 'page-download-texts-modal',
+  selector: 'modal-download-texts',
   templateUrl: 'download-texts.modal.html',
   styleUrls: ['download-texts.modal.scss'],
   imports: [AsyncPipe, NgClass, NgFor, NgIf, NgStyle, NgTemplateOutlet, IonicModule]

--- a/src/theme/_markdown.scss
+++ b/src/theme/_markdown.scss
@@ -153,7 +153,7 @@ page-elastic-search .markdown {
 /* --- */
 
 /* --- Style block: Styles for the markdown content (instructions text) in download texts modal. --- */
-page-download-texts-modal .markdown {
+modal-download-texts .markdown {
 	*:first-child {
 		margin-top: 0;
 	}


### PR DESCRIPTION
BREAKING CHANGE

The selector for the download texts modal has been renamed from <page-download-texts-modal>
to
<modal-download-texts>
in order for it to conform to naming conventions of the app.