### PR TITLE
refactor: remove replacements of .png extension with .svg

### DIFF
--- a/src/app/components/collection-text-types/facsimiles/facsimiles.ts
+++ b/src/app/components/collection-text-types/facsimiles/facsimiles.ts
@@ -162,7 +162,7 @@ export class FacsimilesComponent implements OnInit {
     this.facsURLDefault = config.app.apiEndpoint + '/' + config.app.machineName +
           `/facsimiles/${facs.publication_facsimile_collection_id}/`;
     this.text = this.sanitizer.bypassSecurityTrustHtml(
-      facs.content?.replace(/images\//g, 'assets/images/').replace(/\.png/g, '.svg')
+      facs.content?.replace(/images\//g, 'assets/images/')
     );
 
     if (extImageNr !== undefined) {

--- a/src/app/components/collection-text-types/variants/variants.ts
+++ b/src/app/components/collection-text-types/variants/variants.ts
@@ -109,8 +109,6 @@ export class VariantsComponent implements OnInit {
 
   postprocessVariantText(text: string) {
     text = text.trim();
-    // Replace png images with svg counterparts
-    text = text.replace(/\.png/g, '.svg');
     // Fix image paths
     text = text.replace(/images\//g, 'assets/images/');
     // Add "tei" and "teiVariant" to all classlists

--- a/src/app/dialogs/modals/download-texts/download-texts.modal.ts
+++ b/src/app/dialogs/modals/download-texts/download-texts.modal.ts
@@ -423,7 +423,7 @@ export class DownloadTextsModal implements OnDestroy, OnInit {
   }
 
   private getProcessedPrintIntro(text: string): string {
-    text = text.replace(/images\//g, 'assets/images/').replace(/\.png/g, '.svg');
+    text = text.replace(/images\//g, 'assets/images/');
     text = this.fixImagePaths(text);
     return this.constructHtmlForPrint(text, 'intro');
   }

--- a/src/app/pages/collection/foreword/collection-foreword.ts
+++ b/src/app/pages/collection/foreword/collection-foreword.ts
@@ -86,7 +86,7 @@ export class CollectionForewordPage implements OnDestroy, OnInit {
     return this.collectionContentService.getForeword(id, lang).pipe(
       map((res: any) => {
         if (res?.content && res?.content !== 'File not found') {
-          let text = res.content.replace(/images\//g, 'assets/images/').replace(/\.png/g, '.svg');
+          let text = res.content.replace(/images\//g, 'assets/images/');
           text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
           return this.sanitizer.bypassSecurityTrustHtml(text);
         } else {

--- a/src/app/pages/collection/introduction/collection-introduction.ts
+++ b/src/app/pages/collection/introduction/collection-introduction.ts
@@ -188,7 +188,7 @@ export class CollectionIntroductionPage implements OnInit, OnDestroy {
         if (res?.content) {
           this.textLoading = false;
           // Fix paths for images and file extensions for icons
-          let textContent = res.content.replace(/images\//g, 'assets/images/').replace(/\.png/g, '.svg');
+          let textContent = res.content.replace(/images\//g, 'assets/images/');
 
           // TODO: this manipulation of the introductions TOC should maybe be done using htmlparser2,
           // TODO: on the other hand using regex doesn't rely on an external dependency ...

--- a/src/app/pages/collection/title/collection-title.ts
+++ b/src/app/pages/collection/title/collection-title.ts
@@ -92,7 +92,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
       return this.collectionContentService.getTitle(id, lang).pipe(
         map((res: any) => {
           if (res?.content) {
-            let text = res.content.replace(/images\//g, 'assets/images/').replace(/\.png/g, '.svg');
+            let text = res.content.replace(/images\//g, 'assets/images/');
             text = this.parserService.insertSearchMatchTags(text, this.searchMatches);
             return this.sanitizer.bypassSecurityTrustHtml(text);
           } else {

--- a/src/app/services/comment.service.ts
+++ b/src/app/services/comment.service.ts
@@ -124,8 +124,6 @@ export class CommentService {
   }
 
   private postprocessCommentsText(text: string): string {
-    // Replace png images with svg counterparts
-    text = text.replace(/\.png/g, '.svg');
     // Fix image paths
     text = text.replace(/images\//g, 'assets/images/');
     // Add "teiComment" to all classlists

--- a/src/app/services/html-parser.service.ts
+++ b/src/app/services/html-parser.service.ts
@@ -39,8 +39,6 @@ export class HtmlParserService {
 
     postprocessManuscriptText(text: string) {
         text = text.trim();
-        // Replace png images with svg counterparts
-        text = text.replace(/\.png/g, '.svg');
         // Fix image paths
         text = text.replace(/images\//g, 'assets/images/');
         // Add "tei" and "teiManuscript" to all classlists
@@ -99,7 +97,6 @@ export class HtmlParserService {
     }
 
     mapIllustrationImagePaths(text: string, collectionId: string) {
-        text = text.replace(/\.png/g, '.svg');
         text = text.replace(/images\//g, 'assets/images/');
         text = text.replace(/assets\/images\/verk\/http/g, 'http');
 


### PR DESCRIPTION
The frontend will no longer replace ".png" with ".svg" in any text strings loaded from the backend.