### PR TITLE
fix: ms and variant not loading on invalid type id in URL

### DIFF
--- a/src/app/components/collection-text-types/manuscripts/manuscripts.ts
+++ b/src/app/components/collection-text-types/manuscripts/manuscripts.ts
@@ -84,13 +84,15 @@ export class ManuscriptsComponent implements OnInit {
       })[0];
       if (inputManuscript) {
         this.selectedManuscript = inputManuscript;
+      } else {
+        this.selectedManuscript = this.manuscripts[0];
       }
     } else {
       this.selectedManuscript = this.manuscripts[0];
     }
-    // Emit the ms id so the read page can update queryParams
+    // Emit the ms id so the collection text page can update queryParams
     this.emitSelectedManuscriptId(this.selectedManuscript.id);
-    // Emit the ms name so the read page can display it in the column header
+    // Emit the ms name so the collection text page can display it in the column header
     this.emitSelectedManuscriptName(this.selectedManuscript.name);
     this.changeManuscript();
   }
@@ -164,7 +166,9 @@ export class ManuscriptsComponent implements OnInit {
   }
 
   emitSelectedManuscriptId(id: number) {
-    this.selectedMsID.emit(id);
+    if (this.manuscripts.length > 1) {
+      this.selectedMsID.emit(id);
+    }
   }
 
   emitSelectedManuscriptName(name: string) {

--- a/src/app/components/collection-text-types/variants/variants.ts
+++ b/src/app/components/collection-text-types/variants/variants.ts
@@ -79,6 +79,8 @@ export class VariantsComponent implements OnInit {
       })[0];
       if (inputVariant) {
         this.selectedVariant = inputVariant;
+      } else {
+        this.selectedVariant = this.variants[0];
       }
     } else if (this.sortOrder) {
       const inputVariant = this.variants.filter((item: any) => {
@@ -189,24 +191,30 @@ export class VariantsComponent implements OnInit {
   }
 
   emitOutputValues(variant: any) {
-    // Emit the var id so the read page can update queryParams
+    // Emit the var id so the collection text page can update queryParams
     this.emitSelectedVariantId(variant.id);
-    // Emit the var sort_order so the read page can update queryParams
+    // Emit the var sort_order so the collection text page can update queryParams
     this.emitSelectedVariantSortOrder(variant.sort_order);
-    // Emit the var name so the read page can display it in the column header
+    // Emit the var name so the collection text page can display it in the column header
     this.emitSelectedVariantName(variant.name);
   }
 
   emitSelectedVariantId(id: number) {
-    this.selectedVarID.emit(id);
+    if (this.variants.length > 1) {
+      this.selectedVarID.emit(id);
+    }
   }
 
   emitSelectedVariantName(name: string) {
-    this.selectedVarName.emit(name);
+    if (this.variants.length > 1) {
+      this.selectedVarName.emit(name);
+    }
   }
 
   emitSelectedVariantSortOrder(order: number) {
-    this.selectedVarSortOrder.emit(order);
+    if (this.variants.length > 1) {
+      this.selectedVarSortOrder.emit(order);
+    }
   }
 
   openNewVar(event: Event, id: any) {


### PR DESCRIPTION
If the id of a manuscript or a variant in the URL is invalid with regards to the text id, the first manuscript or variant is displayed instead of an infinite loading spinner. Also, if there is only one manuscript or variant, the URL is not updated with the type id.