### PR TITLE
feature: support adding Open Graph meta tags to document head

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -38,9 +38,13 @@ export class DigitalEditionsApp implements OnDestroy, OnInit {
   }
 
   ngOnInit(): void {
-    this.mobileMode = this.platformService.isMobile() ? true : false;
+    this.mobileMode = this.platformService.isMobile();
     // Side menu is shown by default in desktop mode but not in mobile mode.
     this.showSideNav = !this.mobileMode;
+
+    // Set Open Graph meta tags that are common for all routes. og:title is set by
+    // this.headService.setTitle
+    this.headService.setCommonOpenGraphTags();
 
     this.routerEventsSubscription = this.router.events.pipe(
       filter(event => event instanceof NavigationEnd)
@@ -70,13 +74,13 @@ export class DigitalEditionsApp implements OnDestroy, OnInit {
       // 2. App is starting on the home page in desktop mode.
       if (
         (
-          this.platformService.isMobile() &&
+          this.mobileMode &&
           this.currentRouterUrl.split('?')[0] !== this.previousRouterUrl.split('?')[0]
         ) ||
         (
           this.appIsStarting &&
           !this.currentUrlSegments &&
-          this.platformService.isDesktop()
+          !this.mobileMode
         )
       ) {
         this.showSideNav = false;
@@ -88,10 +92,22 @@ export class DigitalEditionsApp implements OnDestroy, OnInit {
 
       this.setTitleForTopMenuPages(this.currentUrlSegments?.[0]?.path || '');
 
-      this.currentRouterUrl === '/' && this.headService.setMetaProperty('description', $localize`:@@Site.MetaDescription.Home:En generell beskrivning av webbplatsen för sökmotorer.`);
-      this.currentRouterUrl !== '/' && this.headService.setMetaProperty('description', '');
+      if (this.currentRouterUrl === '/') {
+        this.headService.setMetaTag(
+          'name',
+          'description',
+          $localize`:@@Site.MetaDescription.Home:En generell beskrivning av webbplatsen för sökmotorer.`
+        );
+        this.headService.setOpenGraphDescriptionProperty(
+          $localize`:@@Site.MetaDescription.Home:En generell beskrivning av webbplatsen för sökmotorer.`
+        );
+      } else {
+        this.headService.setMetaTag('name', 'description', '');
+        this.headService.setOpenGraphDescriptionProperty('');
+      }
 
       this.headService.setLinks(this.currentRouterUrl);
+      this.headService.setOpenGraphURLProperty(this.currentRouterUrl);
     });
   }
 

--- a/src/app/services/document-head.service.ts
+++ b/src/app/services/document-head.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Renderer2, RendererFactory2 } from '@angular/core';
+import { Inject, Injectable, LOCALE_ID, Renderer2, RendererFactory2 } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Meta, Title } from '@angular/platform-browser';
 
@@ -9,109 +9,189 @@ import { config } from '@config';
   providedIn: 'root',
 })
 export class DocumentHeadService {
-    private currentRouterUrl: string | undefined = undefined;
-    private languages: any[] = [];
-    private renderer: Renderer2;
+  private currentRouterUrl: string | undefined = undefined;
+  private openGraphTags: any = undefined;
+  private languages: any[] = [];
+  private renderer: Renderer2;
 
-    constructor(
-        private meta: Meta,
-        private rendererFactory: RendererFactory2,
-        private title: Title,
-        @Inject(DOCUMENT) private document: Document
-    ) {
-        this.languages = config.app?.i18n?.languages ?? [];
-        this.renderer = this.rendererFactory.createRenderer(null, null);
-    }
+  constructor(
+    private meta: Meta,
+    private rendererFactory: RendererFactory2,
+    private title: Title,
+    @Inject(DOCUMENT) private document: Document,
+    @Inject(LOCALE_ID) private activeLocale: string
+  ) {
+    this.openGraphTags = config.app?.openGraphMetaTags ?? undefined;
+    this.languages = config.app?.i18n?.languages ?? [];
+    this.renderer = this.rendererFactory.createRenderer(null, null);
+  }
 
-    setTitle(pageTitleParts: string[] = []) {
-        let pageTitle = '';
-        for (let i = 0; i < pageTitleParts.length; i++) {
-            if (pageTitleParts[i] && pageTitleParts[i].length) {
-                if (pageTitleParts[i].at(-1) === '.') {
-                    pageTitleParts[i] = pageTitleParts[i].slice(0, -1);
-                }
-                pageTitle = i > 0 ? pageTitle + ' - ' + pageTitleParts[i]
-                    : pageTitleParts[i];
-            }
+  setTitle(pageTitleParts: string[] = []) {
+    let pageTitle = '';
+    for (let i = 0; i < pageTitleParts.length; i++) {
+      if (pageTitleParts[i] && pageTitleParts[i].length) {
+        if (pageTitleParts[i].at(-1) === '.') {
+          pageTitleParts[i] = pageTitleParts[i].slice(0, -1);
         }
-    
-        pageTitle = pageTitle ? pageTitle + ' - ' + $localize`:@@Site.Title:Webbplatsens titel`
-            : $localize`:@@Site.Title:Webbplatsens titel`;
-
-        this.title.setTitle(pageTitle);
+        pageTitle = i > 0 ? pageTitle + ' - ' + pageTitleParts[i]
+          : pageTitleParts[i];
+      }
     }
 
-    setMetaProperty(name: string, content: string) {
-        if (content) {
-            this.meta.updateTag({
-                name: name, 
-                content: content
-            });
-        } else {
-            this.meta.removeTag('name=' + name);
+    if (this.openGraphTags?.enabled) {
+      const ogTitle = pageTitle ? pageTitle : $localize`:@@Site.Title:Webbplatsens titel`;
+      this.setMetaTag('property', 'og:title', ogTitle.replaceAll(' - ', ' – '));
+    }
+
+    pageTitle = pageTitle ? pageTitle + ' - ' + $localize`:@@Site.Title:Webbplatsens titel`
+      : $localize`:@@Site.Title:Webbplatsens titel`;
+
+    this.title.setTitle(pageTitle);
+  }
+
+  setLinks(routerURL: string) {
+    routerURL = this.canonicalizeURL(routerURL);
+    if (routerURL !== this.currentRouterUrl) {
+      this.currentRouterUrl = routerURL;
+
+      const x_default = config.app?.i18n?.defaultLanguage
+        ? config.app.i18n.defaultLanguage
+        : this.languages[0].code;
+
+      // Remove old tags
+      this.removeLinkTags('canonical');
+      this.removeLinkTags('alternate', true);
+
+      // Add new canonical link tag
+      this.addLinkTag('canonical', x_default, routerURL);
+
+      // Add new hreflang link tags
+      if (this.languages.length > 1) {
+        this.languages.forEach(language => {
+          this.addLinkTag('alternate', language.code, routerURL, true);
+        });
+
+        this.addLinkTag('alternate', x_default, routerURL, true, true);
+      }
+    }
+  }
+
+  /**
+   * Sets Open Graph (https://ogp.me/) metadata tags that are
+   * common to all routes.
+   */
+  setCommonOpenGraphTags() {
+    if (this.openGraphTags?.enabled) {
+      // Set og:site_name
+      this.setMetaTag('property', 'og:site_name', $localize`:@@Site.Title:Webbplatsens titel`);
+
+      // Sets og:type
+      this.setMetaTag('property', 'og:type', 'website');
+
+      // Set og:locale and og:locale:alternate
+      const appLocales = config.app?.i18n?.languages ?? [];
+      appLocales.forEach((locale: any) => {
+        const metaProperty = (locale.code === this.activeLocale)
+              ? 'og:locale'
+              : 'og:locale:alternate';
+        const metaContent = locale.code + '_'
+              + (locale.region ? locale.region : locale.code).toUpperCase();
+        this.setMetaTag('property', metaProperty, metaContent);
+      });
+
+      // Set og:image and og:image:alt
+      let imageURL: string = this.openGraphTags?.image?.[this.activeLocale]?.URL
+            ? this.openGraphTags?.image?.[this.activeLocale]?.URL
+            : config.page?.home?.bannerImage?.URL ?? '';
+
+      if (imageURL && !imageURL.startsWith(
+        String(this.document.defaultView?.location.origin) + '/' + this.activeLocale + '/'
+      )) {
+        if (imageURL.at(0) === '/') {
+          imageURL = imageURL.slice(1);
         }
+        imageURL = String(this.document.defaultView?.location.origin)
+              + '/' + this.activeLocale + '/' + imageURL;
+      }
+
+      const altText: string = this.openGraphTags?.image?.[this.activeLocale]?.altText
+            ? this.openGraphTags?.image?.[this.activeLocale]?.altText
+            : config.page?.home?.bannerImage?.altTexts?.[this.activeLocale] ?? 'image';
+      
+      this.setMetaTag('property', 'og:image', imageURL);
+      this.setMetaTag('property', 'og:image:alt', altText);
     }
+  }
 
-    setLinks(routerURL: string) {
-        routerURL = this.canonicalizeURL(routerURL);
-        if (routerURL !== this.currentRouterUrl) {
-            this.currentRouterUrl = routerURL;
-
-            const x_default = config.app?.i18n?.defaultLanguage
-                    ? config.app.i18n.defaultLanguage
-                    : this.languages[0].code;
-
-            // Remove old tags
-            this.removeLinkTags('canonical');
-            this.removeLinkTags('alternate', true);
-
-            // Add new canonical link tag
-            this.addLinkTag('canonical', x_default, routerURL);
-
-            // Add new hreflang link tags
-            if (this.languages.length > 1) {
-                this.languages.forEach(language => {
-                    this.addLinkTag('alternate', language.code, routerURL, true);
-                });
-                
-                this.addLinkTag('alternate', x_default, routerURL, true, true);
-            }
-        }
+  setOpenGraphURLProperty(routerURL: string) {
+    if (this.openGraphTags?.enabled) {
+      this.setMetaTag(
+        'property',
+        'og:url',
+        this.getAbsoluteURL(this.activeLocale + this.canonicalizeURL(routerURL))
+      );
     }
+  }
 
-    private addLinkTag(
-        relType: string,
-        locale: string,
-        routerURL: string,
-        hreflang: boolean = false,
-        x_default: boolean = false
-    ) {
-        const tag: HTMLLinkElement = this.renderer.createElement('link');
-        this.renderer.setAttribute(tag, 'rel', relType);
-        if (hreflang) {
-            !x_default && this.renderer.setAttribute(tag, 'hreflang', locale);
-            x_default && this.renderer.setAttribute(tag, 'hreflang', 'x-default');
-        }
-        this.renderer.setAttribute(tag, 'href', this.getAbsoluteURL(locale + routerURL));
-        this.renderer.appendChild(this.document.head, tag);
+  setOpenGraphDescriptionProperty(description: string) {
+    if (this.openGraphTags?.enabled) {
+      this.setMetaTag('property', 'og:description', description);
     }
+  }
 
-    private removeLinkTags(relType: string, hreflang: boolean = false) {
-        const hreflangAttr = hreflang ? '[hreflang]' : '';
-        const linkTags = this.document.head.querySelectorAll(
-            'link[rel="' + relType + '"]' + hreflangAttr
-        );
-        for (let i = 0; i < linkTags.length; i++) {
-            this.renderer.removeChild(this.document.head, linkTags[i]);
-        }
+  /**
+   * Adds, updates or removes a meta tag from the document <head>.
+   * If 'content' is empty, the tag with attribute defName="defValue"
+   * is removed. If a tag with a defName attribute doesn't exist, it
+   * is added, otherwise it's 'content' is updated.
+   * @param defName value of the name attribute of the meta tag.
+   * @param defValue value of the name attribute of the meta tag.
+   * @param content value of the content attribute of the meta tag.
+   */
+  setMetaTag(defName: string, defValue: string, content?: string) {
+    if (content) {
+      this.meta.updateTag({
+        [defName]: defValue,
+        content: content
+      });
+    } else {
+      this.meta.removeTag(defName + '=' + defValue.replaceAll(':', '\\:'));
     }
+  }
 
-    private getAbsoluteURL(relativeURL: string) {
-        return String(this.document.defaultView?.location.origin) + '/' + relativeURL;
+  private addLinkTag(
+    relType: string,
+    locale: string,
+    routerURL: string,
+    hreflang: boolean = false,
+    x_default: boolean = false
+  ) {
+    const tag: HTMLLinkElement = this.renderer.createElement('link');
+    this.renderer.setAttribute(tag, 'rel', relType);
+    if (hreflang) {
+      !x_default && this.renderer.setAttribute(tag, 'hreflang', locale);
+      x_default && this.renderer.setAttribute(tag, 'hreflang', 'x-default');
     }
+    this.renderer.setAttribute(tag, 'href', this.getAbsoluteURL(locale + routerURL));
+    this.renderer.appendChild(this.document.head, tag);
+  }
 
-    private canonicalizeURL(url: string): string {
-        return url.split('?')[0];
+  private removeLinkTags(relType: string, hreflang: boolean = false) {
+    const hreflangAttr = hreflang ? '[hreflang]' : '';
+    const linkTags = this.document.head.querySelectorAll(
+      'link[rel="' + relType + '"]' + hreflangAttr
+    );
+    for (let i = 0; i < linkTags.length; i++) {
+      this.renderer.removeChild(this.document.head, linkTags[i]);
     }
-    
+  }
+
+  private getAbsoluteURL(relativeURL: string) {
+    return String(this.document.defaultView?.location.origin) + '/' + relativeURL;
+  }
+
+  private canonicalizeURL(url: string): string {
+    return url.split('?')[0];
+  }
+
 }

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -12,15 +12,28 @@ export const config: Config = {
     facsimileBase: "",
     i18n: {
       languages: [
-        { code: "sv", label: "Svenska" },
-        { code: "fi", label: "Suomi" }
+        { code: "sv", label: "Svenska", region: "FI" },
+        { code: "fi", label: "Suomi", region: "FI" }
       ],
       defaultLanguage: "sv",
       multilingualCollectionTableOfContents: false,
       multilingualReadingTextLanguages: [],
       multilingualNamedEntityData: false
     },
-    enableRouterLoadingBar: true
+    enableRouterLoadingBar: true,
+    openGraphMetaTags: {
+      enabled: true,
+      image: {
+        sv: {
+          altText: "alt-text",
+          URL: "assets/images/home-page-banner.jpg"
+        },
+        fi: {
+          altText: "alt-teksti",
+          URL: "assets/images/home-page-banner.jpg"
+        }
+      }
+    }
   },
   collections: {
     coversMarkdownFolderNumber: "08",
@@ -400,7 +413,7 @@ export const config_soderholm: Config = {
     apiEndpoint: "https://api.sls.fi/digitaledition",
     i18n: {
       languages: [
-        { code: "sv", label: "Svenska" }
+        { code: "sv", label: "Svenska", region: "FI" }
       ],
       defaultLanguage: "sv",
       multilingualCollectionTableOfContents: false,
@@ -760,7 +773,7 @@ export const config_vonWright: Config = {
     apiEndpoint: "https://api.sls.fi/digitaledition",
     i18n: {
       languages: [
-        { code: "sv", label: "Svenska" }
+        { code: "sv", label: "Svenska", region: "FI" }
       ],
       defaultLanguage: "sv",
       multilingualCollectionTableOfContents: false,
@@ -1015,9 +1028,9 @@ export const config_granqvist: Config = {
     apiEndpoint: "https://api.sls.fi/digitaledition",
     i18n: {
       languages: [
-        { code: "sv", label: "Svenska" },
-        { code: "en", label: "English" },
-        { code: "ar", label: "Arabic" },
+        { code: "sv", label: "Svenska", region: "FI" },
+        { code: "en", label: "English", region: "GB" },
+        { code: "ar", label: "Arabic", region: "AR" },
       ],
       defaultLanguage: "sv",
       multilingualCollectionTableOfContents: false,
@@ -1341,8 +1354,8 @@ export const config_mechelin: Config = {
     facsimileBase: "https://leomechelin-facsimiles.storage.googleapis.com/facsimile_collection",
     i18n: {
       languages: [
-        { code: "sv", label: "Svenska" },
-        { code: "fi", label: "Suomi" }
+        { code: "sv", label: "Svenska", region: "FI" },
+        { code: "fi", label: "Suomi", region: "FI" }
       ],
       defaultLanguage: "sv",
       multilingualCollectionTableOfContents: true,


### PR DESCRIPTION
Open Graph meta tags (https://ogp.me/) can now be generated automatically to the app's document head for each page.

To enable this feature, set app.openGraphMetaTags.enabled to true in config.ts.

If enabled, the following new information needs to be added to the config:

In each object in the app.i18n.languages array, add the key "region". It's value must be a two letter uppercase region identifier. For instance, in the locale ID sv-FI, FI is the region identifier. Example:

```
languages: [
        { code: "sv", label: "Svenska", region: "FI" },
        { code: "fi", label: "Suomi", region: "FI" }
]
```

Add app.openGraphMetaTags.image as an object. It has to have a sub-object for each language with two keys: URL and altText. URL is the URL to an image file for the Open Graph protocol, and altText is the alt-text of the image. Example:

```
openGraphMetaTags: {
      enabled: true,
      image: {
        sv: {
          altText: "alt-text",
          URL: "assets/images/home-page-banner.jpg"
        },
        fi: {
          altText: "alt-teksti",
          URL: "assets/images/home-page-banner.jpg"
        }
     }
 }
```