### PR TITLE
feature: open collection side menu on nav from content page

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -86,6 +86,14 @@ export class DigitalEditionsApp implements OnDestroy, OnInit {
         this.showSideNav = false;
       }
 
+      // Open side menu if user navigated to a collection page from the content page
+      if (
+        this.currentUrlSegments?.[0]?.path === 'collection' &&
+        this.previousRouterUrl === '/content'
+      ) {
+        this.showSideNav = true;
+      }
+
       if (this.appIsStarting) {
         this.appIsStarting = false;
       }


### PR DESCRIPTION
The collection side menu is now open when navigating to a collection from the content page.