### PR TITLE
refactor: rename some config keys & CSS

### DIFF
--- a/generate_sitemap.js
+++ b/generate_sitemap.js
@@ -11,8 +11,8 @@ async function generateSitemap() {
     console.log('Generating sitemap ...');
     const config = getConfig();
 
-    const projectName = config.app?.machineName ?? '';
-    const API = config.app?.apiEndpoint ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
+    const API = config.app?.backendBaseURL ?? '';
     let urlOrigin = config.app?.siteURLOrigin ?? '';
     const locale = config.app?.i18n?.defaultLanguage ?? 'sv';
     const multilingualCollectionTOC = config.app?.i18n?.multilingualCollectionTableOfContents ?? false;

--- a/src/app/components/collection-text-types/facsimiles/facsimiles.ts
+++ b/src/app/components/collection-text-types/facsimiles/facsimiles.ts
@@ -53,8 +53,8 @@ export class FacsimilesComponent implements OnInit {
     private sanitizer: DomSanitizer
   ) {
     this.facsSize = config.component?.facsimiles?.imageQuality ?? 1;
-    this.facsURLAlternate = config.app?.facsimileBase ?? '';
-    this.showTitle = config.component?.facsimiles?.showFacsimileTitle ?? true;
+    this.facsURLAlternate = config.app?.alternateFacsimileBaseURL ?? '';
+    this.showTitle = config.component?.facsimiles?.showTitle ?? true;
   }
 
   ngOnInit() {
@@ -159,7 +159,7 @@ export class FacsimilesComponent implements OnInit {
     this.selectedFacsimileIsExternal = false;
     this.selectedFacsimile = facs;
     this.numberOfImages = facs.number_of_pages;
-    this.facsURLDefault = config.app.apiEndpoint + '/' + config.app.machineName +
+    this.facsURLDefault = config.app.backendBaseURL + '/' + config.app.projectNameDB +
           `/facsimiles/${facs.publication_facsimile_collection_id}/`;
     this.text = this.sanitizer.bypassSecurityTrustHtml(
       facs.content?.replace(/images\//g, 'assets/images/')

--- a/src/app/components/collection-text-types/reading-text/reading-text.html
+++ b/src/app/components/collection-text-types/reading-text/reading-text.html
@@ -7,7 +7,7 @@
       [class.show_personInfo]="viewOptionsService.show.personInfo"
       [class.show_placeInfo]="viewOptionsService.show.placeInfo"
       [class.show_workInfo]="viewOptionsService.show.workInfo"
-      [class.show_changes]="viewOptionsService.show.changes"
+      [class.show_emendations]="viewOptionsService.show.emendations"
       [class.show_normalisations]="viewOptionsService.show.normalisations"
       [class.show_abbreviations]="viewOptionsService.show.abbreviations"
       [class.show_paragraphNumbering]="viewOptionsService.show.paragraphNumbering"

--- a/src/app/components/epub-viewer/epub-viewer.ts
+++ b/src/app/components/epub-viewer/epub-viewer.ts
@@ -554,7 +554,7 @@ export class EpubViewerComponent implements AfterViewInit, OnDestroy, OnInit {
       'personInfo': false,
       'placeInfo': false,
       'workInfo': false,
-      'changes': false,
+      'emendations': false,
       'normalisations': false,
       'abbreviations': false,
       'paragraphNumbering': false,

--- a/src/app/components/menus/top/top-menu.ts
+++ b/src/app/components/menus/top/top-menu.ts
@@ -55,9 +55,9 @@ export class TopMenuComponent implements OnDestroy, OnInit {
     this.showTopAboutButton = config.component?.topMenu?.showAboutButton ?? true;
     this.showSiteLogo = config.component?.topMenu?.showSiteLogo ?? false;
 
-    this.siteLogoLinkUrl = config.component?.topMenu?.siteLogoLinkUrl ?? 'https://www.sls.fi/';
-    this.siteLogoDefaultImageUrl = config.component?.topMenu?.siteLogoDefaultImageUrl ?? 'assets/images/logo.svg';
-    this.siteLogoMobileImageUrl = config.component?.topMenu?.siteLogoMobileImageUrl ?? 'assets/images/logo-mobile.svg';
+    this.siteLogoLinkUrl = config.component?.topMenu?.siteLogoLinkURL ?? 'https://www.sls.fi/';
+    this.siteLogoDefaultImageUrl = config.component?.topMenu?.siteLogoDefaultImageURL ?? 'assets/images/logo.svg';
+    this.siteLogoMobileImageUrl = config.component?.topMenu?.siteLogoMobileImageURL ?? 'assets/images/logo-mobile.svg';
 
     if (!this.siteLogoMobileImageUrl && this.siteLogoDefaultImageUrl) {
       this.siteLogoMobileImageUrl = this.siteLogoDefaultImageUrl;

--- a/src/app/dialogs/modals/illustration/illustration.modal.ts
+++ b/src/app/dialogs/modals/illustration/illustration.modal.ts
@@ -36,8 +36,8 @@ export class IllustrationModal implements OnInit {
       (data: any) => {
         this.imgMetadata = data;
         if (data?.media_collection_id && data?.image_filename_front) {
-          this.imgPath = config.app.apiEndpoint + '/'
-          + config.app.machineName + '/gallery/get/'
+          this.imgPath = config.app.backendBaseURL + '/'
+          + config.app.projectNameDB + '/gallery/get/'
           + data.media_collection_id + '/'
           + data.image_filename_front;
         }

--- a/src/app/dialogs/popovers/view-options/view-options.popover.html
+++ b/src/app/dialogs/popovers/view-options/view-options.popover.html
@@ -78,8 +78,8 @@
     <ion-toggle class="show_abbreviations" [(ngModel)]="show.abbreviations" (ionChange)="toggleOption('abbreviations')" justify="space-between" [enableOnOffLabels]="true" i18n="@@ViewOptions.Abbreviations">Förkortningar</ion-toggle>
   </ion-item>
 
-  <ion-item *ngIf="availableToggles.changes">
-    <ion-toggle class="show_changesInfo" [(ngModel)]="show.changes" (ionChange)="toggleOption('changes')" justify="space-between" [enableOnOffLabels]="true" i18n="@@ViewOptions.Emendations">Utgivarens ändringar</ion-toggle>
+  <ion-item *ngIf="availableToggles.emendations">
+    <ion-toggle class="show_emendationsInfo" [(ngModel)]="show.emendations" (ionChange)="toggleOption('emendations')" justify="space-between" [enableOnOffLabels]="true" i18n="@@ViewOptions.Emendations">Utgivarens ändringar</ion-toggle>
   </ion-item>
 
   <ion-item *ngIf="availableToggles.normalisations">

--- a/src/app/dialogs/popovers/view-options/view-options.popover.scss
+++ b/src/app/dialogs/popovers/view-options/view-options.popover.scss
@@ -94,8 +94,8 @@ ion-button.text-xlarge {
 .show_abbreviations {
 	background-color: var(--abbreviations-color, #ffe2fa);
 }
-.show_changesInfo {
-	background-color: var(--changes-color, #ccc);
+.show_emendationsInfo {
+	background-color: var(--emendations-color, #ccc);
 }
 .show_normalisationsInfo {
 	background-color: var(--normalisations-color, #e6e6e6);

--- a/src/app/dialogs/popovers/view-options/view-options.popover.ts
+++ b/src/app/dialogs/popovers/view-options/view-options.popover.ts
@@ -26,7 +26,7 @@ export class ViewOptionsPopover implements OnDestroy, OnInit {
     personInfo: false,
     placeInfo: false,
     workInfo: false,
-    changes: false,
+    emendations: false,
     normalisations: false,
     abbreviations: false,
     paragraphNumbering: false,
@@ -97,8 +97,8 @@ export class ViewOptionsPopover implements OnDestroy, OnInit {
       if (this.availableToggles.workInfo) {
         this.show.workInfo = true;
       }
-      if (this.availableToggles.changes) {
-        this.show.changes = true;
+      if (this.availableToggles.emendations) {
+        this.show.emendations = true;
       }
       if (this.availableToggles.normalisations) {
         this.show.normalisations = true;
@@ -121,7 +121,7 @@ export class ViewOptionsPopover implements OnDestroy, OnInit {
       this.show.personInfo = false;
       this.show.placeInfo = false;
       this.show.workInfo = false;
-      this.show.changes = false;
+      this.show.emendations = false;
       this.show.normalisations = false;
       this.show.abbreviations = false;
       this.show.paragraphNumbering = false;
@@ -134,7 +134,7 @@ export class ViewOptionsPopover implements OnDestroy, OnInit {
     this.toggleOption('personInfo');
     this.toggleOption('placeInfo');
     this.toggleOption('workInfo');
-    this.toggleOption('changes');
+    this.toggleOption('emendations');
     this.toggleOption('normalisations');
     this.toggleOption('abbreviations');
     this.toggleOption('paragraphNumbering');

--- a/src/app/pages/collection/foreword/collection-foreword.ts
+++ b/src/app/pages/collection/foreword/collection-foreword.ts
@@ -110,7 +110,7 @@ export class CollectionForewordPage implements OnDestroy, OnInit {
       'personInfo': false,
       'placeInfo': false,
       'workInfo': false,
-      'changes': false,
+      'emendations': false,
       'normalisations': false,
       'abbreviations': false,
       'paragraphNumbering': false,

--- a/src/app/pages/collection/introduction/collection-introduction.ts
+++ b/src/app/pages/collection/introduction/collection-introduction.ts
@@ -105,7 +105,7 @@ export class CollectionIntroductionPage implements OnInit, OnDestroy {
         'personInfo': false,
         'placeInfo': false,
         'workInfo': false,
-        'changes': false,
+        'emendations': false,
         'normalisations': false,
         'abbreviations': false,
         'paragraphNumbering': true,
@@ -114,7 +114,7 @@ export class CollectionIntroductionPage implements OnInit, OnDestroy {
       };
     } else {
       this.viewOptionsTogglesIntro.comments = false;
-      this.viewOptionsTogglesIntro.changes = false;
+      this.viewOptionsTogglesIntro.emendations = false;
       this.viewOptionsTogglesIntro.normalisations = false;
       this.viewOptionsTogglesIntro.abbreviations = false;
       this.viewOptionsTogglesIntro.pageBreakOriginal = false;

--- a/src/app/pages/collection/text/collection-text.html
+++ b/src/app/pages/collection/text/collection-text.html
@@ -466,7 +466,7 @@
         [class.show_placeInfo]="viewOptionsService.show.placeInfo"
         [class.show_workInfo]="viewOptionsService.show.workInfo"
         [class.show_normalisations]="viewOptionsService.show.normalisations"
-        [class.show_changes]="viewOptionsService.show.changes"
+        [class.show_emendations]="viewOptionsService.show.emendations"
         [class.show_abbreviations]="viewOptionsService.show.abbreviations"
         [ngStyle]="{'position': toolTipPosType, 'top': toolTipPosition.top, 'left': toolTipPosition.left, 'max-width': toolTipMaxWidth, 'transform': 'scale(' + toolTipScaleValue + ')'}"
         [innerHTML]="toolTipText"
@@ -479,7 +479,7 @@
         [class.show_placeInfo]="viewOptionsService.show.placeInfo"
         [class.show_workInfo]="viewOptionsService.show.workInfo"
         [class.show_normalisations]="viewOptionsService.show.normalisations"
-        [class.show_changes]="viewOptionsService.show.changes"
+        [class.show_emendations]="viewOptionsService.show.emendations"
         [class.show_abbreviations]="viewOptionsService.show.abbreviations"
         [ngStyle]="{'position': infoOverlayPosType, 'bottom': infoOverlayPosition.bottom, 'left': infoOverlayPosition.left, 'width': infoOverlayWidth}"
   >

--- a/src/app/pages/collection/text/collection-text.ts
+++ b/src/app/pages/collection/text/collection-text.ts
@@ -469,8 +469,11 @@ export class CollectionTextPage implements OnDestroy, OnInit {
             }
           } else if (
             (
-              eventTarget['classList'].contains('ttChanges') &&
-              this.viewOptionsService.show.changes
+              (
+                eventTarget['classList'].contains('ttChanges') ||
+                eventTarget['classList'].contains('ttEmendations')
+               ) &&
+              this.viewOptionsService.show.emendations
             ) ||
             (
               eventTarget['classList'].contains('ttNormalisations') &&
@@ -922,8 +925,11 @@ export class CollectionTextPage implements OnDestroy, OnInit {
               }
             } else if (
               (
-                eventTarget['classList'].contains('ttChanges') &&
-                this.viewOptionsService.show.changes
+                (
+                  eventTarget['classList'].contains('ttChanges') ||
+                  eventTarget['classList'].contains('ttEmendations')
+                ) &&
+                this.viewOptionsService.show.emendations
               ) || (
                 eventTarget['classList'].contains('ttNormalisations') &&
                 this.viewOptionsService.show.normalisations
@@ -1049,7 +1055,7 @@ export class CollectionTextPage implements OnDestroy, OnInit {
   }
 
   /**
-   * This function is used for showing tooltips for changes,
+   * This function is used for showing tooltips for emendations,
    * normalisations, abbreviations and explanations in manuscripts.
    */
   private showTooltipFromInlineHtml(targetElem: HTMLElement) {
@@ -1111,7 +1117,7 @@ export class CollectionTextPage implements OnDestroy, OnInit {
   }
 
   /**
-   * This function is used for showing infoOverlays for changes,
+   * This function is used for showing infoOverlays for emendations,
    * normalisations and abbreviations, and also comments if they
    * are present inline in the text.
    */

--- a/src/app/pages/collection/title/collection-title.ts
+++ b/src/app/pages/collection/title/collection-title.ts
@@ -133,7 +133,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
       'personInfo': false,
       'placeInfo': false,
       'workInfo': false,
-      'changes': false,
+      'emendations': false,
       'normalisations': false,
       'abbreviations': false,
       'paragraphNumbering': false,

--- a/src/app/pages/media-collection/media-collection.ts
+++ b/src/app/pages/media-collection/media-collection.ts
@@ -64,8 +64,8 @@ export class MediaCollectionPage implements OnDestroy, OnInit {
     private urlService: UrlService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
-    this.apiEndPoint = config.app?.apiEndpoint ?? '';
-    this.projectName = config.app?.machineName ?? '';
+    this.apiEndPoint = config.app?.backendBaseURL ?? '';
+    this.projectName = config.app?.projectNameDB ?? '';
     this.showURNButton = config.page?.mediaCollection?.showURNButton ?? false;
 
     this.filterSelectOptions = {

--- a/src/app/services/collection-content.service.ts
+++ b/src/app/services/collection-content.service.ts
@@ -19,8 +19,8 @@ export class CollectionContentService {
   constructor(
     private http: HttpClient
   ) {
-    const apiBaseURL = config.app?.apiEndpoint ?? '';
-    const projectName = config.app?.machineName ?? '';
+    const apiBaseURL = config.app?.backendBaseURL ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
   }
 

--- a/src/app/services/collection-toc.service.ts
+++ b/src/app/services/collection-toc.service.ts
@@ -18,8 +18,8 @@ export class CollectionTableOfContentsService {
     private http: HttpClient,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
-    const apiBaseURL = config.app?.apiEndpoint ?? '';
-    const projectName = config.app?.machineName ?? '';
+    const apiBaseURL = config.app?.backendBaseURL ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
     this.multilingualTOC = config.app?.i18n?.multilingualCollectionTableOfContents ?? false;
   }

--- a/src/app/services/collections.service.ts
+++ b/src/app/services/collections.service.ts
@@ -16,8 +16,8 @@ export class CollectionsService {
     private http: HttpClient,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
-    const apiBaseURL = config.app?.apiEndpoint ?? '';
-    const projectName = config.app?.machineName ?? '';
+    const apiBaseURL = config.app?.backendBaseURL ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
     this.multilingualTOC = config.app?.i18n?.multilingualCollectionTableOfContents ?? false;
   }

--- a/src/app/services/comment.service.ts
+++ b/src/app/services/comment.service.ts
@@ -15,8 +15,8 @@ export class CommentService {
   constructor(
     private http: HttpClient
   ) {
-    const apiBaseURL = config.app?.apiEndpoint ?? '';
-    const projectName = config.app?.machineName ?? '';
+    const apiBaseURL = config.app?.backendBaseURL ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
   }
 

--- a/src/app/services/elastic-search.service.ts
+++ b/src/app/services/elastic-search.service.ts
@@ -24,8 +24,8 @@ export class ElasticSearchService {
     this.indices = config.page?.elasticSearch?.indices ?? [];
     this.fixedFilters = config.page?.elasticSearch?.fixedFilters ?? [];
     this.textTypes = config.page?.elasticSearch?.typeFilterGroupOptions ?? [];
-    const apiBaseURL = config.app?.apiEndpoint ?? '';
-    const projectName = config.app?.machineName ?? '';
+    const apiBaseURL = config.app?.backendBaseURL ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
     this.searchURL = apiBaseURL + '/' + projectName + '/search/elastic/' + this.indices.join(',');
 
     // Add fields that should always be returned in hits

--- a/src/app/services/html-parser.service.ts
+++ b/src/app/services/html-parser.service.ts
@@ -19,8 +19,8 @@ export class HtmlParserService {
   constructor(
     private collectionContentService: CollectionContentService
   ) {
-    const apiBaseURL = config.app?.apiEndpoint ?? '';
-    const projectName = config.app?.machineName ?? '';
+    const apiBaseURL = config.app?.backendBaseURL ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
   }
 

--- a/src/app/services/markdown-content.service.ts
+++ b/src/app/services/markdown-content.service.ts
@@ -14,8 +14,8 @@ export class MarkdownContentService {
   constructor(
     private http: HttpClient
   ) {
-    const apiBaseURL = config.app?.apiEndpoint ?? '';
-    const projectName = config.app?.machineName ?? '';
+    const apiBaseURL = config.app?.backendBaseURL ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
   }
 

--- a/src/app/services/media-collection.service.ts
+++ b/src/app/services/media-collection.service.ts
@@ -15,8 +15,8 @@ export class MediaCollectionService {
   constructor(
     private http: HttpClient
   ) {
-    const apiBaseURL = config.app?.apiEndpoint ?? '';
-    const projectName = config.app?.machineName ?? '';
+    const apiBaseURL = config.app?.backendBaseURL ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
   }
 

--- a/src/app/services/named-entity.service.ts
+++ b/src/app/services/named-entity.service.ts
@@ -21,8 +21,8 @@ export class NamedEntityService {
     private http: HttpClient,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
-    const apiBaseURL = config.app?.apiEndpoint ?? '';
-    const projectName = config.app?.machineName ?? '';
+    const apiBaseURL = config.app?.backendBaseURL ?? '';
+    const projectName = config.app?.projectNameDB ?? '';
     this.apiURL = apiBaseURL + '/' + projectName;
     this.multilingual = config.app?.i18n?.multilingualNamedEntityData ?? false;
   }
@@ -49,7 +49,7 @@ export class NamedEntityService {
    */
   getEntityOccurrences(type: string, id: string): Observable<any> {
     type = convertNamedEntityTypeForBackend(type);
-    const endpoint = `${config.app.apiEndpoint}/occurrences/${type}/${id}`;
+    const endpoint = `${config.app.backendBaseURL}/occurrences/${type}/${id}`;
     return this.http.get(endpoint);
   }
 

--- a/src/app/services/reference-data.service.ts
+++ b/src/app/services/reference-data.service.ts
@@ -29,7 +29,7 @@ export class ReferenceDataService {
 
     // We need to double encode the URL for the API
     url = encodeURI(encodeURIComponent(url));
-    const endpoint = `${config.app.apiEndpoint}/${config.app.machineName}/urn/${url}/`;
+    const endpoint = `${config.app.backendBaseURL}/${config.app.projectNameDB}/urn/${url}/`;
 
     return this.http.get(endpoint).pipe(
       switchMap((data: any) => {

--- a/src/app/services/view-options.service.ts
+++ b/src/app/services/view-options.service.ts
@@ -15,7 +15,7 @@ export class ViewOptionsService {
     abbreviations: false,
     placeInfo: false,
     workInfo: false,
-    changes: false,
+    emendations: false,
     normalisations: false,
     paragraphNumbering: false,
     pageBreakOriginal: false,

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -6,10 +6,10 @@ type Config = { [key: string]: any }
 export const config: Config = {
   app: {
     siteURLOrigin: "https://topelius.sls.fi",
-    machineName: "topelius",
+    projectNameDB: "topelius",
     projectId: 10,
-    apiEndpoint: "https://testa-vonwright.sls.fi:8000/digitaledition",
-    facsimileBase: "",
+    backendBaseURL: "https://testa-vonwright.sls.fi:8000/digitaledition",
+    alternateFacsimileBaseURL: "",
     i18n: {
       languages: [
         { code: "sv", label: "Svenska", region: "FI" },
@@ -266,7 +266,7 @@ export const config: Config = {
         comments: true,
         personInfo: true,
         placeInfo: true,
-        changes: true,
+        emendations: true,
         normalisations: true,
         workInfo: true,
         abbreviations: true,
@@ -316,7 +316,7 @@ export const config: Config = {
     },
     facsimiles: {
       imageQuality: 4,
-      showFacsimileTitle: true
+      showTitle: true
     },
     mainSideMenu: {
       items: {
@@ -342,9 +342,9 @@ export const config: Config = {
       showURNButton: false,
       showLanguageButton: true,
       showSiteLogo: true,
-      siteLogoDefaultImageUrl: "assets/images/logo.svg",
-      siteLogoMobileImageUrl: "assets/images/logo-mobile.svg",
-      siteLogoLinkUrl: "https://www.sls.fi/"
+      siteLogoDefaultImageURL: "assets/images/logo.svg",
+      siteLogoMobileImageURL: "assets/images/logo-mobile.svg",
+      siteLogoLinkURL: "https://www.sls.fi/"
     },
     variants: {
       showOpenLegendButton: true
@@ -408,9 +408,9 @@ export const config: Config = {
 export const config_soderholm: Config = {
   app: {
     siteURLOrigin: "https://soderholm.sls.fi",
-    machineName: "soderholm",
+    projectNameDB: "soderholm",
     projectId: 7,
-    apiEndpoint: "https://api.sls.fi/digitaledition",
+    backendBaseURL: "https://api.sls.fi/digitaledition",
     i18n: {
       languages: [
         { code: "sv", label: "Svenska", region: "FI" }
@@ -639,7 +639,7 @@ export const config_soderholm: Config = {
         comments: false,
         personInfo: false,
         placeInfo: false,
-        changes: false,
+        emendations: false,
         normalisations: false,
         workInfo: false,
         abbreviations: false,
@@ -684,7 +684,7 @@ export const config_soderholm: Config = {
     },
     facsimiles: {
       imageQuality: 2,
-      showFacsimileTitle: false
+      showTitle: false
     },
     mainSideMenu: {
       items: {
@@ -710,9 +710,9 @@ export const config_soderholm: Config = {
       showURNButton: false,
       showLanguageButton: false,
       showSiteLogo: true,
-      siteLogoDefaultImageUrl: "assets/images/logo.svg",
-      siteLogoMobileImageUrl: "assets/images/logo-mobile.svg",
-      siteLogoLinkUrl: "https://www.sls.fi/"
+      siteLogoDefaultImageURL: "assets/images/logo.svg",
+      siteLogoMobileImageURL: "assets/images/logo-mobile.svg",
+      siteLogoLinkURL: "https://www.sls.fi/"
     },
     variants: {
       showOpenLegendButton: false
@@ -768,9 +768,9 @@ export const config_soderholm: Config = {
 export const config_vonWright: Config = {
   app: {
     siteURLOrigin: "https://vonwright.sls.fi",
-    machineName: "vonwright",
+    projectNameDB: "vonwright",
     projectId: 6,
-    apiEndpoint: "https://api.sls.fi/digitaledition",
+    backendBaseURL: "https://api.sls.fi/digitaledition",
     i18n: {
       languages: [
         { code: "sv", label: "Svenska", region: "FI" }
@@ -902,7 +902,7 @@ export const config_vonWright: Config = {
         comments: true,
         personInfo: true,
         placeInfo: true,
-        changes: true,
+        emendations: true,
         normalisations: true,
         workInfo: true,
         abbreviations: false,
@@ -947,7 +947,7 @@ export const config_vonWright: Config = {
     },
     facsimiles: {
       imageQuality: 4,
-      showFacsimileTitle: false
+      showTitle: false
     },
     mainSideMenu: {
       items: {
@@ -972,9 +972,9 @@ export const config_vonWright: Config = {
       showURNButton: false,
       showLanguageButton: false,
       showSiteLogo: true,
-      siteLogoDefaultImageUrl: "assets/images/logo.svg",
-      siteLogoMobileImageUrl: "assets/images/logo-mobile.svg",
-      siteLogoLinkUrl: "https://www.sls.fi/"
+      siteLogoDefaultImageURL: "assets/images/logo.svg",
+      siteLogoMobileImageURL: "assets/images/logo-mobile.svg",
+      siteLogoLinkURL: "https://www.sls.fi/"
     },
     variants: {
       showOpenLegendButton: false
@@ -1023,9 +1023,9 @@ export const config_vonWright: Config = {
 export const config_granqvist: Config = {
   app: {
     siteURLOrigin: "https://granqvist.sls.fi",
-    machineName: "granqvist",
+    projectNameDB: "granqvist",
     projectId: 2,
-    apiEndpoint: "https://api.sls.fi/digitaledition",
+    backendBaseURL: "https://api.sls.fi/digitaledition",
     i18n: {
       languages: [
         { code: "sv", label: "Svenska", region: "FI" },
@@ -1268,7 +1268,7 @@ export const config_granqvist: Config = {
     },
     facsimiles: {
       imageQuality: 1,
-      showFacsimileTitle: false
+      showTitle: false
     },
     mainSideMenu: {
       items: {
@@ -1293,9 +1293,9 @@ export const config_granqvist: Config = {
       showURNButton: false,
       showLanguageButton: true,
       showSiteLogo: true,
-      siteLogoDefaultImageUrl: "assets/images/logo.svg",
-      siteLogoMobileImageUrl: "assets/images/logo-mobile.svg",
-      siteLogoLinkUrl: "https://www.sls.fi/"
+      siteLogoDefaultImageURL: "assets/images/logo.svg",
+      siteLogoMobileImageURL: "assets/images/logo-mobile.svg",
+      siteLogoLinkURL: "https://www.sls.fi/"
     },
     variants: {
       showOpenLegendButton: false
@@ -1348,10 +1348,10 @@ export const config_granqvist: Config = {
 export const config_mechelin: Config = {
   app: {
     siteURLOrigin: "https://leomechelin.fi",
-    machineName: "leomechelin",
+    projectNameDB: "leomechelin",
     projectId: 1,
-    apiEndpoint: "https://leomechelin.fi/api",
-    facsimileBase: "https://leomechelin-facsimiles.storage.googleapis.com/facsimile_collection",
+    backendBaseURL: "https://leomechelin.fi/api",
+    alternateFacsimileBaseURL: "https://leomechelin-facsimiles.storage.googleapis.com/facsimile_collection",
     i18n: {
       languages: [
         { code: "sv", label: "Svenska", region: "FI" },
@@ -1433,7 +1433,7 @@ export const config_mechelin: Config = {
         comments: true,
         personInfo: true,
         placeInfo: false,
-        changes: true,
+        emendations: true,
         normalisations: true,
         workInfo: false,
         abbreviations: true,
@@ -1478,7 +1478,7 @@ export const config_mechelin: Config = {
     },
     facsimiles: {
       imageQuality: 1,
-      showFacsimileTitle: false
+      showTitle: false
     },
     mainSideMenu: {
       items: {
@@ -1504,9 +1504,9 @@ export const config_mechelin: Config = {
       showURNButton: false,
       showLanguageButton: true,
       showSiteLogo: false,
-      siteLogoDefaultImageUrl: "assets/images/logo.svg",
-      siteLogoMobileImageUrl: "assets/images/logo-mobile.svg",
-      siteLogoLinkUrl: ""
+      siteLogoDefaultImageURL: "assets/images/logo.svg",
+      siteLogoMobileImageURL: "assets/images/logo-mobile.svg",
+      siteLogoLinkURL: ""
     },
     variants: {
       showOpenLegendButton: false

--- a/src/assets/custom_css/custom.scss
+++ b/src/assets/custom_css/custom.scss
@@ -103,7 +103,7 @@
 
   ion-app[class][class] {
     --abbreviations-color: #ffe2fa;
-    --changes-color: #ccc;
+    --emendations-color: #ccc;
     --normalisations-color: #e6e6e6;
     --pageBreakEdition-color: #8f6b28;
     --pageBreakOriginal-color: #b32fa0;

--- a/src/theme/TEI/_tei-core.scss
+++ b/src/theme/TEI/_tei-core.scss
@@ -186,56 +186,56 @@ been removed from the text, or in variants, text that is
 missing.
 */
 div.tei.show_normalisations span.reg_hide img,
-div.tei.show_changes span.corr_hide img,
+div.tei.show_emendations span.corr_hide img,
 div.tei span.seg img {
     display: inline-block;
     width:   0.625em; // default if the font size is not working
     height:  0.625em;
 }
 .miniFontSize div.tei.show_normalisations span.reg_hide img,
-.miniFontSize div.tei.show_changes span.corr_hide img,
+.miniFontSize div.tei.show_emendations span.corr_hide img,
 .miniFontSize div.tei span.seg img {
     width:  ceil(0.585 * $text-fontsize-mini);
     height: ceil(0.585 * $text-fontsize-mini);
 }
 .tinyFontSize div.tei.show_normalisations span.reg_hide img,
-.tinyFontSize div.tei.show_changes span.corr_hide img,
+.tinyFontSize div.tei.show_emendations span.corr_hide img,
 .tinyFontSize div.tei span.seg img {
     width:  ceil(0.585 * $text-fontsize-tiny);
     height: ceil(0.585 * $text-fontsize-tiny);
 }
 .xxsmallFontSize div.tei.show_normalisations span.reg_hide img,
-.xxsmallFontSize div.tei.show_changes span.corr_hide img,
+.xxsmallFontSize div.tei.show_emendations span.corr_hide img,
 .xxsmallFontSize div.tei span.seg img {
     width:  ceil(0.585 * $text-fontsize-xxsmall);
     height: ceil(0.585 * $text-fontsize-xxsmall);
 }
 .xsmallFontSize div.tei.show_normalisations span.reg_hide img,
-.xsmallFontSize div.tei.show_changes span.corr_hide img,
+.xsmallFontSize div.tei.show_emendations span.corr_hide img,
 .xsmallFontSize div.tei span.seg img {
     width:  ceil(0.585 * $text-fontsize-xsmall);
     height: ceil(0.585 * $text-fontsize-xsmall);
 }
 .smallFontSize div.tei.show_normalisations span.reg_hide img,
-.smallFontSize div.tei.show_changes span.corr_hide img,
+.smallFontSize div.tei.show_emendations span.corr_hide img,
 .smallFontSize div.tei span.seg img {
     width:  ceil(0.585 * $text-fontsize-small);
     height: ceil(0.585 * $text-fontsize-small);
 }
 .mediumFontSize div.tei.show_normalisations span.reg_hide img,
-.mediumFontSize div.tei.show_changes span.corr_hide img,
+.mediumFontSize div.tei.show_emendations span.corr_hide img,
 .mediumFontSize div.tei span.seg img {
     width:  ceil(0.585 * $text-fontsize-medium);
     height: ceil(0.585 * $text-fontsize-medium);
 }
 .largeFontSize div.tei.show_normalisations span.reg_hide img,
-.largeFontSize div.tei.show_changes span.corr_hide img,
+.largeFontSize div.tei.show_emendations span.corr_hide img,
 .largeFontSize div.tei span.seg img {
     width:  ceil(0.585 * $text-fontsize-large);
     height: ceil(0.585 * $text-fontsize-large);
 }
 .xlargeFontSize div.tei.show_normalisations span.reg_hide img,
-.xlargeFontSize div.tei.show_changes span.corr_hide img,
+.xlargeFontSize div.tei.show_emendations span.corr_hide img,
 .xlargeFontSize div.tei span.seg img {
     width:  ceil(0.585 * $text-fontsize-xlarge);
     height: ceil(0.585 * $text-fontsize-xlarge);
@@ -2180,10 +2180,10 @@ from div.tei
 .infoOverlay.show_placeInfo .infoOverlayContent p.infoOverlayText span.placeName,
 .infoOverlay.show_workInfo .infoOverlayContent p.footnoteText span.title,
 .infoOverlay.show_workInfo .infoOverlayContent p.infoOverlayText span.title,
-.infoOverlay.show_changes .infoOverlayContent p.footnoteText span.corr,
-.infoOverlay.show_changes .infoOverlayContent p.infoOverlayText span.corr,
-.infoOverlay.show_changes .infoOverlayContent p.footnoteText span.corr_red,
-.infoOverlay.show_changes .infoOverlayContent p.infoOverlayText span.corr_red,
+.infoOverlay.show_emendations .infoOverlayContent p.footnoteText span.corr,
+.infoOverlay.show_emendations .infoOverlayContent p.infoOverlayText span.corr,
+.infoOverlay.show_emendations .infoOverlayContent p.footnoteText span.corr_red,
+.infoOverlay.show_emendations .infoOverlayContent p.infoOverlayText span.corr_red,
 .infoOverlay.show_normalisations .infoOverlayContent p.footnoteText span.reg,
 .infoOverlay.show_normalisations .infoOverlayContent p.infoOverlayText span.reg,
 .infoOverlay.show_abbreviations .infoOverlayContent p.footnoteText span.abbr,
@@ -2193,35 +2193,59 @@ from div.tei
 }
 
 
-/* Advanced mode styles */
-div.tei .tooltip { display: none; }
-.tei                        img.comment { display: none; }
-.tei.show_comments          img.comment { display: inline-block; cursor: pointer; top: 0; }
-
-.tei.show_personInfo        span.person { background-color: var(--persName-color, #f9e0bf); cursor: pointer; }
-
-.tei.show_placeInfo         span.placeName { background-color: var(--placeName-color, #dee8ca); cursor: pointer; }
-
-.tei.show_workInfo          span.title { background-color: var(--workTitle-color, #f7efba); cursor: pointer; }
-
-.tei.show_abbreviations     span.abbr { background-color: var(--abbreviations-color, #ffe2fa); cursor: pointer; }
-
-.tei.show_changes           span.corr, 
-.tei.show_changes           span.corr_red { background-color: var(--changes-color, #ccc); cursor: pointer; }
-.tei                        span.corr_hide { display: none; }
-
-.tei.show_normalisations    span.reg.ttNormalisations { background-color: var(--normalisations-color, #e6e6e6); cursor: pointer; }
-.tei                        span.reg_hide { display: none; }
-.tei.show_normalisations    span.reg_hide,
-.tei.show_changes           span.corr_hide { display: inline; cursor: pointer; }
-
-
-
-/* PARAGRAPH AND LINE NUMBERING */
+/* Advanced mode styles, paragraph and line numberings */
+div.tei .tooltip,
+.tei img.comment,
+.tei span.corr_hide,
+.tei span.reg_hide,
 .tei span.lNumber,
 .tei span.paragraph_number {
     display: none;
 }
+
+.tei.show_comments img.comment {
+    display: inline-block;
+    cursor: pointer;
+    top: 0;
+}
+
+.tei.show_personInfo span.person {
+    background-color: var(--persName-color, #f9e0bf);
+    cursor: pointer;
+}
+
+.tei.show_placeInfo span.placeName {
+    background-color: var(--placeName-color, #dee8ca);
+    cursor: pointer;
+}
+
+.tei.show_workInfo span.title {
+    background-color: var(--workTitle-color, #f7efba);
+    cursor: pointer;
+}
+
+.tei.show_abbreviations span.abbr {
+    background-color: var(--abbreviations-color, #ffe2fa);
+    cursor: pointer;
+}
+
+.tei.show_emendations span.corr, 
+.tei.show_emendations span.corr_red {
+    background-color: var(--emendations-color, #ccc);
+    cursor: pointer;
+}
+
+.tei.show_normalisations span.reg.ttNormalisations {
+    background-color: var(--normalisations-color, #e6e6e6);
+    cursor: pointer;
+}
+
+.tei.show_normalisations span.reg_hide,
+.tei.show_emendations span.corr_hide {
+    display: inline;
+    cursor: pointer;
+} 
+
 .tei.show_paragraphNumbering span.paragraph_number,
 .tei.show_paragraphNumbering span.lNumber {
     display: block;

--- a/src/theme/scoped-variables/_semantic-code-variables.scss
+++ b/src/theme/scoped-variables/_semantic-code-variables.scss
@@ -10,7 +10,7 @@
 
 :host {
   --abbreviations-color: #ffe2fa;
-  --changes-color: #ccc;
+  --emendations-color: #ccc;
   --normalisations-color: #e6e6e6;
   --pageBreakEdition-color: #8f6b28;
   --pageBreakOriginal-color: #b32fa0;


### PR DESCRIPTION
BREAKING CHANGES

* Renamed keys in config.ts:

app.machineName
--> app.projectNameDB

app.apiEndpoint
--> app.backendBaseURL

app.facsimileBase
--> app.alternateFacsimileBaseURL

page.text.viewOptions.changes
--> page.text.viewOptions.emendations

component.facsimiles.showFacsimileTitle
--> component.facsimiles.showTitle

component.topMenu.siteLogoDefaultImageUrl
--> component.topMenu.siteLogoDefaultImageURL

component.topMenu.siteLogoMobileImageUrl
--> component.topMenu.siteLogoMobileImageURL

component.topMenu.siteLogoLinkUrl
--> component.topMenu.siteLogoLinkURL

* Renamed CSS-classes:

.show_changes --> .show_emendations

* Renamed CSS variables: --changes-color --> --emendations-color