### PR TITLE
feature: customize text-changer colors in mobile mode by CSS variables

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -3,6 +3,7 @@
 @import "src/theme/scoped-variables/secondary-toolbar-variables.scss";
 @import "src/theme/scoped-variables/semantic-code-variables.scss";
 @import "src/theme/scoped-variables/side-menu-variables.scss";
+@import "src/theme/scoped-variables/text-changer-variables.scss";
 @import "src/theme/scoped-variables/top-menu-variables.scss";
 
 header {

--- a/src/app/components/text-changer/text-changer.scss
+++ b/src/app/components/text-changer/text-changer.scss
@@ -9,8 +9,8 @@
 }
 
 :host(.text-changer-mobile-mode) {
-  background-color: #cbcbcb;
-  color: #000;
+  background-color: var(--text-changer-mobile-color);
+  color: var(--text-changer-mobile-color-contrast);
   height: 46px;
   padding: 0;
 }

--- a/src/assets/custom_css/custom.scss
+++ b/src/assets/custom_css/custom.scss
@@ -102,21 +102,21 @@
   }
 
   ion-app[class][class] {
-    --abbreviations-color: #ffe2fa;
-    --emendations-color: #ccc;
-    --normalisations-color: #e6e6e6;
-    --pageBreakEdition-color: #8f6b28;
+    --abbreviations-color:     #ffe2fa;
+    --emendations-color:       #ccc;
+    --normalisations-color:    #e6e6e6;
+    --pageBreakEdition-color:  #8f6b28;
     --pageBreakOriginal-color: #b32fa0;
-    --persName-color: #f9e0bf;
-    --placeName-color: #dee8ca;
-    --workTitle-color: #f7efba;
+    --persName-color:          #f9e0bf;
+    --placeName-color:         #dee8ca;
+    --workTitle-color:         #f7efba;
 
     --info-overlay-background-color: #333;
     --info-overlay-text-color:       #e3e3e3;
     --info-overlay-link-color:       #84cce3;
 
-    --secondary-toolbar-color:              var(--secondary-color);
-    --secondary-toolbar-color-contrast:     var(--secondary-color-contrast);
+    --secondary-toolbar-color:          var(--secondary-color);
+    --secondary-toolbar-color-contrast: var(--secondary-color-contrast);
 
     --side-menu-text-color:                        #000;
     --side-menu-background-color:                  var(--main-background-color);
@@ -133,6 +133,9 @@
     --side-menu-selected-background-color:         transparent;
     --side-menu-selected-hover-color:              var(--side-menu-hover-color);
     --side-menu-selected-description-text-color:   var(--side-menu-description-text-color);
+
+    --text-changer-mobile-color:          var(--secondary-toolbar-color);
+    --text-changer-mobile-color-contrast: var(--secondary-toolbar-color-contrast);
 
     --top-menu-height:                         62px;
     --top-menu-toolbar-button-icons-font-size: 1.875rem;

--- a/src/theme/scoped-variables/_semantic-code-variables.scss
+++ b/src/theme/scoped-variables/_semantic-code-variables.scss
@@ -9,12 +9,12 @@
 */
 
 :host {
-  --abbreviations-color: #ffe2fa;
-  --emendations-color: #ccc;
-  --normalisations-color: #e6e6e6;
-  --pageBreakEdition-color: #8f6b28;
+  --abbreviations-color:     #ffe2fa;
+  --emendations-color:       #ccc;
+  --normalisations-color:    #e6e6e6;
+  --pageBreakEdition-color:  #8f6b28;
   --pageBreakOriginal-color: #b32fa0;
-  --persName-color: #f9e0bf;
-  --placeName-color: #dee8ca;
-  --workTitle-color: #f7efba;
+  --persName-color:          #f9e0bf;
+  --placeName-color:         #dee8ca;
+  --workTitle-color:         #f7efba;
 }

--- a/src/theme/scoped-variables/_text-changer-variables.scss
+++ b/src/theme/scoped-variables/_text-changer-variables.scss
@@ -1,0 +1,16 @@
+/*
+  Text changer CSS variables scoped to <ion-app> by import, so in practice these are
+  global, though they won’t be included in the global styles.css.
+
+  To override any of these variables in custom.scss you must use
+  this selector for defining the scope:
+
+  ion-app[class][class] { }
+*/
+
+ion-app {
+  // Component colors in mobile mode. In desktop mode the component inherits
+  // it’s colors from the parent element (secondary toolbar).
+  --text-changer-mobile-color:          var(--secondary-toolbar-color);
+  --text-changer-mobile-color-contrast: var(--secondary-toolbar-color-contrast);
+}


### PR DESCRIPTION
By default, the text-changer has the same colors in mobile mode as the secondary toolbar.