### PR TITLE
refactor: server files

### DIFF
--- a/proxy-server.js
+++ b/proxy-server.js
@@ -1,30 +1,42 @@
 const express = require("express");
 const path = require("path");
 
+// * Define language codes of all languages the app is available in.
+// * A translated server will be started for each of these.
+// * The first language in the array is treated as default for the app.
+const languages = ["sv", "fi"];
+
 const getTranslatedServer = (lang) => {
-    const distFolder = path.join(
-        process.cwd(),
-        `dist/app/server/${lang}`
-    );
-    const server = require(`${distFolder}/main.js`);
-    return server.app(lang);
+  const distFolder = path.join(
+    process.cwd(),
+    `dist/app/server/${lang}`
+  );
+  const server = require(`${distFolder}/main.js`);
+  return server.app(lang);
 };
 
 function run() {
-    const port = process.env['PORT'] || 4201;
+  const port = process.env['PORT'] || 4201;
+  const translatedServers = {};
 
-    // Start up the Node server
-    const appFi = getTranslatedServer("fi");
-    const appSv = getTranslatedServer("sv");
+  // Start up the Node server in each language.
 
-    const server = express();
-    server.use("/fi", appFi);
-    server.use("/sv", appSv);
-    server.use("", appSv);
+  languages.forEach(langCode => {
+    translatedServers[langCode] = getTranslatedServer(langCode);
+  });
 
-    server.listen(port, () => {
-        console.log(`Node Express server listening on http://localhost:${port}`);
-    });
+  const server = express();
+
+  for (const [langCode, langServer] of Object.entries(translatedServers)) {
+    server.use(`/${langCode}`, langServer);
+  }
+
+  // Use default language server if no language code defined in route.
+  server.use("", translatedServers[languages[0]]);
+
+  server.listen(port, () => {
+    console.log(`Node Express server listening on http://localhost:${port}`);
+  });
 }
 
 run();

--- a/server.ts
+++ b/server.ts
@@ -15,68 +15,70 @@ import { environment } from './src/environments/environment';
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(lang: string): express.Express {
-    const server = express();
-    const distFolder = join(process.cwd(), `dist/app/browser/${lang}`);
-    const indexHtml = existsSync(join(distFolder, 'index.original.html')) ? 'index.original.html' : 'index';
+  const server = express();
+  const distFolder = join(process.cwd(), `dist/app/browser/${lang}`);
+  const indexHtml = existsSync(join(distFolder, 'index.original.html')) ? 'index.original.html' : 'index';
 
-    // Our Universal express-engine (found @ https://github.com/angular/universal/tree/main/modules/express-engine)
-    
-    // SK 31.5.2023: Added inlineCriticalCss: false. See:
-    // https://github.com/angular/universal/issues/2106
-    // https://github.com/angular/angular/issues/42098
-    // Also added optimization property that disables inlineCritical
-    // in angular.json: architect.build.configurations.production
-    server.engine('html', ngExpressEngine({
-        bootstrap: AppServerModule,
-        extraProviders: [{ provide: LOCALE_ID, useValue: lang }],
-        inlineCriticalCss: false,
-    } as any));
+  // Our Universal express-engine (found @ https://github.com/angular/universal/tree/main/modules/express-engine)
 
-    server.set('view engine', 'html');
-    server.set('views', distFolder);
+  // SK 31.5.2023: Added inlineCriticalCss: false. See:
+  // https://github.com/angular/universal/issues/2106
+  // https://github.com/angular/angular/issues/42098
+  // Also added optimization property that disables inlineCritical
+  // in angular.json: architect.build.configurations.production
+  server.engine('html', ngExpressEngine({
+    bootstrap: AppServerModule,
+    extraProviders: [{ provide: LOCALE_ID, useValue: lang }],
+    inlineCriticalCss: false,
+  } as any));
 
-    // Example Express Rest API endpoints
-    // server.get('/api/**', (req, res) => { });
-    // Serve static files from /browser
-    server.get('*.*', express.static(distFolder, {
-        maxAge: '1y'
-    }));
+  server.set('view engine', 'html');
+  server.set('views', distFolder);
 
-    // All regular routes use the Universal engine
-    server.get('*', (req, res) => {
-        res.render(indexHtml, {req, providers: [
-            {provide: APP_BASE_HREF, useValue: req.baseUrl},
-            {provide: LOCALE_ID, useValue: lang}
-        ]});
+  // Example Express Rest API endpoints
+  // server.get('/api/**', (req, res) => { });
+  // Serve static files from /browser
+  server.get('*.*', express.static(distFolder, {
+    maxAge: '1y'
+  }));
+
+  // All regular routes use the Universal engine
+  server.get('*', (req, res) => {
+    res.render(indexHtml, {
+      req, providers: [
+        { provide: APP_BASE_HREF, useValue: req.baseUrl },
+        { provide: LOCALE_ID, useValue: lang }
+      ]
     });
+  });
 
-    return server;
+  return server;
 }
 
-// ! SK 18.10.2023: This function doesn't seem to be used.
-function run(): void {
-    const port = process.env['PORT'] || 4000;
+// * In production mode, the server is started by proxy-server.js
+// * and this function is never run.
+function runDev(): void {
+  const port = process.env['PORT'] || 4000;
 
-    // Start up the Node server
-    const appFr = app('fr');
-    const appEn = app('en');
-    const server = express();
-    server.use('/fr', appFr);
-    server.use('/en', appEn);
-    server.use('' , appFr);
-    server.listen(port, () => {
-        console.log(`Node Express server listening on http://localhost:${port}`);
-    });
+  // Start up the Node server
+  const appSv = app('sv');
+  const server = express();
+  server.use('/sv', appSv);
+  server.use('', appSv);
+  server.listen(port, () => {
+    console.log(`Node Express dev server listening on http://localhost:${port}`);
+  });
 }
 
 // Webpack will replace 'require' with '__webpack_require__'
 // '__non_webpack_require__' is a proxy to Node 'require'
 // The below code is to ensure that the server is run only when not requiring the bundle.
+// * This is run ONLY in development mode!
 declare const __non_webpack_require__: NodeRequire;
 const mainModule = __non_webpack_require__.main;
 const moduleFilename = mainModule && mainModule.filename || '';
 if (!environment.production && moduleFilename === __filename || moduleFilename.includes('iisnode')) {
-    run();
+  runDev();
 }
 
 export * from './src/main.server';

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -1,11 +1,10 @@
 import { NgModule } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
+import { IonicServerModule } from '@ionic/angular-server';
 
 import { AppModule } from './app.module';
-
-// Tell Ionic components how to render on the server
-import { IonicServerModule } from '@ionic/angular-server';
 import { DigitalEditionsApp } from './app.component';
+
 
 @NgModule({
   imports: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,6 @@ function bootstrap() {
     .catch(err => console.log(err));
 };
 
-
 if (document.readyState === 'complete') {
   bootstrap();
 } else {


### PR DESCRIPTION
In proxy-server.js it is now enough to define the app languages in an array at the top of the file. Translated servers will be created for each of the languages. No other modifications need to be done in the file when changing internationalization options for different projects.