### PR TITLE
refactor: hard code markdown folder IDs

### DIFF
--- a/generate_sitemap.js
+++ b/generate_sitemap.js
@@ -42,7 +42,7 @@ async function generateSitemap() {
     if (config.component?.mainSideMenu?.items?.about) {
         let aboutPages = await fetchFromAPI(APIBase + '/static-pages-toc/' + locale);
         if (aboutPages && aboutPages.children) {
-            urlCounter += generateAboutPagesURLs(aboutPages.children, (config.page?.about?.markdownFolderNumber ?? '03'), urlOrigin, locale);
+            urlCounter += generateAboutPagesURLs(aboutPages.children, '03', urlOrigin, locale);
         }
     }
 

--- a/src/app/components/content-grid/content-grid.component.ts
+++ b/src/app/components/content-grid/content-grid.component.ts
@@ -20,7 +20,6 @@ import { MarkdownContentService } from '@services/markdown-content.service';
 })
 export class ContentGridComponent implements OnInit {
   availableEbooks: any[] = [];
-  collectionCoversFolderId: string = '';
   collectionSortOrder: any[] = [];
   contentItems$: Observable<ContentItem[]>;
   includeEbooks: boolean = false;
@@ -33,7 +32,6 @@ export class ContentGridComponent implements OnInit {
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
     this.availableEbooks = config.ebooks ?? [];
-    this.collectionCoversFolderId = config.collections?.coversMarkdownFolderNumber ?? '08';
     this.collectionSortOrder = config.collections?.order ?? [];
     this.includeEbooks = config.component?.contentGrid?.includeEbooks ?? false;
     this.includeMediaCollection = config.component?.contentGrid?.includeMediaCollection ?? false;
@@ -86,7 +84,7 @@ export class ContentGridComponent implements OnInit {
           // parallell, to fetch sequentially you'd use concatMap)
           mergeMap(
             (collection: any) => 
-              this.mdContentService.getMdContent(`${this.activeLocale}-${this.collectionCoversFolderId}-${collection.id}`).pipe(
+              this.mdContentService.getMdContent(`${this.activeLocale}-08-${collection.id}`).pipe(
                 // add image alt-text and cover URL from response to collection data
                 map((coverRes: any) => ({
                   ...collection,

--- a/src/app/components/menus/main-side/main-side-menu.component.ts
+++ b/src/app/components/menus/main-side/main-side-menu.component.ts
@@ -24,7 +24,6 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
   @Input() urlSegments: UrlSegment[] = [];
 
   _config = config;
-  aboutPagesRootNodeID: string = '';
   ebooksList: any[] = [];
   highlightedMenu: string = '';
   mainMenu: any[] = [];
@@ -42,7 +41,6 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
     private mediaCollectionService: MediaCollectionService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
-    this.aboutPagesRootNodeID = this._config.page?.about?.markdownFolderNumber ?? '03';
     this.ebooksList = this._config.ebooks ?? [];
 
     if (this.ebooksList) {
@@ -138,7 +136,7 @@ export class MainSideMenuComponent implements OnInit, OnChanges {
 
   private getAboutPagesMenu(): Observable<any> {
     return this.mdcontentService.getMenuTree(
-      this.activeLocale, this.aboutPagesRootNodeID
+      this.activeLocale, '03'
     ).pipe(
       map((res: any) => {
         res = [res];

--- a/src/app/components/menus/top/top-menu.component.ts
+++ b/src/app/components/menus/top/top-menu.component.ts
@@ -63,9 +63,8 @@ export class TopMenuComponent implements OnDestroy, OnInit {
       this.siteLogoMobileImageUrl = this.siteLogoDefaultImageUrl;
     }
 
-    const aboutPagesFolderNumber = config.page?.about?.markdownFolderNumber ?? '03';
     const initialAboutPageNode = config.page?.about?.initialPageNode ?? '01';
-    this.firstAboutPageId = aboutPagesFolderNumber + "-" + initialAboutPageNode;
+    this.firstAboutPageId = "03-" + initialAboutPageNode;
 
     this.languages = config.app?.i18n?.languages ?? [];
     this.languages.forEach((languageObj: any) => {

--- a/src/app/pages/collection/cover/collection-cover.page.ts
+++ b/src/app/pages/collection/cover/collection-cover.page.ts
@@ -14,7 +14,6 @@ import { PlatformService } from '@services/platform.service';
 })
 export class CollectionCoverPage implements OnInit {
   collectionID: string = '';
-  coverMdFolderId: string = '08';
   coverData$: Observable<any>;
   mobileMode: boolean = false;
 
@@ -23,9 +22,7 @@ export class CollectionCoverPage implements OnInit {
     private platformService: PlatformService,
     private route: ActivatedRoute,
     @Inject(LOCALE_ID) private activeLocale: string
-  ) {
-    this.coverMdFolderId = config.collections?.coversMarkdownFolderNumber ?? '08';
-  }
+  ) {}
 
   ngOnInit() {
     this.mobileMode = this.platformService.isMobile();
@@ -36,7 +33,7 @@ export class CollectionCoverPage implements OnInit {
       }),
       switchMap(({collectionID}) => {
         return this.getCoverDataFromMdContent(
-          `${this.activeLocale}-${this.coverMdFolderId}-${collectionID}`
+          `${this.activeLocale}-08-${collectionID}`
         );
       })
     );

--- a/src/app/pages/collection/title/collection-title.page.html
+++ b/src/app/pages/collection/title/collection-title.page.html
@@ -26,10 +26,10 @@
         [class.xlargeFontSize]="textsize == TextsizeEnum.XLarge"
   >
     <div *ngIf="(text$ | async) as text; else loading"
-          [class.tei]="!titleFromMarkdownFolderId"
-          [class.teiContainer]="!titleFromMarkdownFolderId"
-          [class.markdown]="titleFromMarkdownFolderId"
-          [class.md_content]="titleFromMarkdownFolderId"
+          [class.tei]="!loadContentFromMarkdown"
+          [class.teiContainer]="!loadContentFromMarkdown"
+          [class.markdown]="loadContentFromMarkdown"
+          [class.md_content]="loadContentFromMarkdown"
           [innerHTML]="text"
     ></div>
     <ng-template #loading>

--- a/src/app/pages/collection/title/collection-title.page.ts
+++ b/src/app/pages/collection/title/collection-title.page.ts
@@ -25,11 +25,11 @@ import { ViewOptionsService } from '@services/view-options.service';
 export class CollectionTitlePage implements OnDestroy, OnInit {
   collectionID: string = '';
   intervalTimerId: number = 0;
+  loadContentFromMarkdown: boolean = false;
   mobileMode: boolean = false;
   searchMatches: string[] = [];
   showURNButton: boolean = false;
   showViewOptionsButton: boolean = true;
-  titleFromMarkdownFolderId: string = '';
   text$: Observable<SafeHtml>;
   textsize: Textsize = Textsize.Small;
   textsizeSubscription: Subscription | null = null;
@@ -50,7 +50,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
     private viewOptionsService: ViewOptionsService,
     @Inject(LOCALE_ID) private activeLocale: string
   ) {
-    this.titleFromMarkdownFolderId = config.collections?.titlesMarkdownFolderNumber ?? '';
+    this.loadContentFromMarkdown = config.page?.title?.loadContentFromMarkdown ?? false;
     this.showURNButton = config.page?.title?.showURNButton ?? false;
     this.showViewOptionsButton = config.page?.title?.showViewOptionsButton ?? true;
   }
@@ -88,7 +88,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
   }
 
   private loadTitle(id: string, lang: string): Observable<SafeHtml> {
-    if (!this.titleFromMarkdownFolderId) {
+    if (!this.loadContentFromMarkdown) {
       return this.collectionContentService.getTitle(id, lang).pipe(
         map((res: any) => {
           if (res?.content) {
@@ -109,7 +109,7 @@ export class CollectionTitlePage implements OnDestroy, OnInit {
         })
       );
     } else {
-      return this.getMdContent(`${lang}-${this.titleFromMarkdownFolderId}-${id}`);
+      return this.getMdContent(`${lang}-09-${id}`);
     }
   }
 

--- a/src/assets/config/config.ts
+++ b/src/assets/config/config.ts
@@ -33,8 +33,6 @@ export const config: Config = {
     }
   },
   collections: {
-    coversMarkdownFolderNumber: "08",
-    titlesMarkdownFolderNumber: "",
     enableLegacyIDs: true,
     enableMathJax: false,
     firstTextItem: {
@@ -110,7 +108,6 @@ export const config: Config = {
   ],
   page: {
     about: {
-      markdownFolderNumber: "03",
       initialPageNode: "01-01"
     },
     elasticSearch: {
@@ -284,6 +281,7 @@ export const config: Config = {
       }
     },
     title: {
+      loadContentFromMarkdown: false,
       showURNButton: true,
       showViewOptionsButton: true
     }


### PR DESCRIPTION
BREAKING CHANGES

Most IDs of markdown folders for loading additional content to various pages have been hard coded, with three exceptions. These three are now also hard coded.

In the backend files, the folder for collection covers must now be /md/<language>/08. For collection title pages it must be /md/<language>/09 and for about pages /md/<language>/03. These are now hard coded and cannot be customized in the config.

Furthermore, to enable collection title page content to be loaded from markdown (instead of the default xml/html based backend endpoint), the following config option needs to be set to true: page.title.loadContentFromMarkdown (it's default is false)

Most projects are already using these hard coded folder IDs, so no action is needed from them, except to clean out the removed keys from config.ts.

Removed keys in config.ts:
collections.coversMarkdownFolderNumber
collections.titlesMarkdownFolderNumber
page.about.markdownFolderNumber

Added keys in config.ts:
page.title.loadContentFromMarkdown (boolean; defaults to false)