### PR TITLE
fix: set page head title of positioned TOC item to parent non-positioned TOC item title

### DIFF
--- a/src/app/components/menus/collection-side/collection-side-menu.component.ts
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.ts
@@ -135,7 +135,7 @@ export class CollectionSideMenuComponent implements OnInit, OnChanges, OnDestroy
     this.highlightedMenu = itemId;
     const isFrontMatterPage = this.setTitleForFrontMatterPages();
     if (!isFrontMatterPage) {
-      const item = this.recursiveFinding(this.collectionMenu, itemId);
+      const item = this.recursiveFinding(this.collectionMenu, itemId.split(';')[0]);
       if (item && !this.selectedMenu.includes(item.itemId || item.nodeId)) {
         this.selectedMenu.push(item.itemId || item.nodeId);
       }


### PR DESCRIPTION
Previously, when navigating to specific positions a reading-text with positions, the head title of the page was set to the positioned TOC item's title. This was incorrect, because the positioned headings in the reading-text were still on the same page. After this update, the head title is set to the non-positioned parent TOC item.

For instance, in Topelius Fältskärns berättelser, navigating to the chapter "1. Slaget vid Breitenfeld" does not set the page head title to this, but rather to "Första berättelsen. Konungens Ring", since this is the title of the page where the specific chapter is just one part where the reading-text can be scrolled to.