### PR TITLE
refactor(collection text): set next as active view on removal in mobile mode

### DIFF
--- a/src/app/pages/collection/text/collection-text.page.ts
+++ b/src/app/pages/collection/text/collection-text.page.ts
@@ -1512,8 +1512,10 @@ export class CollectionTextPage implements OnDestroy, OnInit {
     this.views.splice(i, 1);
     this.updateViewsInRouterQueryParams(this.views);
 
-    // In mobile mode, change the active view
-    const index = i > 0 ? i - 1 : 0;
+    // In mobile mode, set the next view in the views array
+    // as the active view, or the previous view if the deleted
+    // one was the last view in the array.
+    const index = i < this.views.length ? i : i - 1;
     this.setActiveMobileModeViewType(undefined, undefined, index);
   }
 


### PR DESCRIPTION
When removing the active view in mobile mode on the collection text page. the new active view is now set to the next view in the views array. If the removed view was the last view in the array, the active view is set to the new last view in the array.