### PR TITLE
refactor(collection side menu): change back link target and icon

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -39,11 +39,12 @@ export class DigitalEditionApp implements OnDestroy, OnInit {
 
   ngOnInit(): void {
     this.mobileMode = this.platformService.isMobile();
-    // Side menu is shown by default in desktop mode but not in mobile mode.
+    // Side menu is shown by default in desktop mode but not in
+    // mobile mode.
     this.showSideNav = !this.mobileMode;
 
-    // Set Open Graph meta tags that are common for all routes. og:title is set by
-    // this.headService.setTitle
+    // Set Open Graph meta tags that are common for all routes.
+    // og:title is set by this.headService.setTitle
     this.headService.setCommonOpenGraphTags();
 
     this.routerEventsSubscription = this.router.events.pipe(
@@ -53,25 +54,30 @@ export class DigitalEditionApp implements OnDestroy, OnInit {
       this.currentRouterUrl = event.url;
       const currentUrlTree: UrlTree = this.router.parseUrl(event.url);
       this.currentUrlSegments = currentUrlTree?.root?.children[PRIMARY_OUTLET]?.segments;
+      console.log(currentUrlTree);
 
-      // Check if a collection-page in order to show collection side menu instead of main side menu.
+      // Check if a collection page in order to show collection side
+      // menu instead of main side menu.
       if (this.currentUrlSegments?.[0]?.path === 'collection') {
         this.collectionID = this.currentUrlSegments[1]?.path || '';
         this.collectionSideMenuInitialUrlSegments = this.currentUrlSegments;
         this.collectionSideMenuInitialQueryParams = currentUrlTree?.queryParams;
         this.showCollectionSideMenu = true;
       } else {
-        // If the app is started on a collection-page the main side menu is not immediately
-        // created in order to increase performance. Once the user leaves the collection-pages
-        // the side menu gets created and stays mounted. It is hidden with css if the user
-        // visits a collection-page and the collection side menu is displayed.
+        // If the app is started on a collection-page the main side menu
+        // is not immediately created in order to increase performance.
+        // Once the user leaves the collection pages the side menu gets
+        // created and stays mounted. It is hidden with css if the user
+        // visits a collection page and the collection side menu is
+        // displayed.
         this.mountMainSideMenu = true;
         this.showCollectionSideMenu = false;
       }
 
-      // Hide side menu:
-      // 1. After navigation event in mobile mode if navigating to a new url (queryParams not taken into account).
-      // 2. App is starting on the home page in desktop mode.
+      // Hide side menu if:
+      // 1. navigating to a new url in mobile mode (changes to
+      //    queryParams disregarded).
+      // 2. app is starting on the home page in desktop mode.
       if (
         (
           this.mobileMode &&
@@ -86,10 +92,15 @@ export class DigitalEditionApp implements OnDestroy, OnInit {
         this.showSideNav = false;
       }
 
-      // Open side menu if user navigated to a collection page from the content page
+      // Open side menu if:
+      // 1. user navigated to a collection page from the content page
+      // 2. queryParams contains menu=open
       if (
-        this.currentUrlSegments?.[0]?.path === 'collection' &&
-        this.previousRouterUrl === '/content'
+        (
+          this.currentUrlSegments?.[0]?.path === 'collection' &&
+          this.previousRouterUrl === '/content'
+        ) ||
+        currentUrlTree?.queryParams?.menu === 'open'
       ) {
         this.showSideNav = true;
       }

--- a/src/app/components/menus/collection-side/collection-side-menu.component.html
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.html
@@ -1,6 +1,9 @@
 <ng-container *ngIf="!isLoading">
   <div class="menu-header">
-    <a class="go-back-menu-item" [routerLink]="['/']"><ion-icon name="arrow-back-sharp"></ion-icon> <span i18n="@@CollectionSideMenu.Back">Tillbaka</span></a>
+    <a class="go-back-menu-item" [routerLink]="['/content']" [queryParams]="{ menu: 'open' }">
+      <ion-icon aria-hidden="true" name="chevron-back-outline"></ion-icon>
+      <span i18n="@@CollectionSideMenu.Back">Tillbaka</span>
+    </a>
     <h2 id="side-menu-collection-title">{{collectionTitle}}</h2>
   </div>
   <div class="sort-select-wrapper" *ngIf="sortOptions.length > 0">

--- a/src/app/components/menus/collection-side/collection-side-menu.component.scss
+++ b/src/app/components/menus/collection-side/collection-side-menu.component.scss
@@ -4,27 +4,27 @@
 .menu-header {
   display: flex;
   flex-flow: column nowrap;
-  width: 100%;
   position: sticky;
   top: 0;
+  width: 100%;
   z-index: 999;
 
   .go-back-menu-item {
-    background-color: var(--side-menu-back-button-background-color);
-    color: var(--side-menu-back-button-text-color);
-    font-size: 1rem;
-    text-decoration: none;
-    display: flex;
-    flex-wrap: nowrap;
     align-items: center;
-    font-weight: normal;
-    margin: 0;
+    background-color: var(--side-menu-back-button-background-color);
     border-left: 4px solid transparent;
+    color: var(--side-menu-back-button-text-color);
+    display: flex;
+    font-size: 1rem;
+    font-weight: normal;
+    height: 50px;
+    margin: 0;
     padding: 11px 18px 11px 6px;
+    text-decoration: none;
 
     ion-icon {
       color: var(--side-menu-back-button-text-color);
-      font-size: 1.75rem;
+      font-size: 1.25rem;
       margin-right: 0.5rem;
     }
   }
@@ -40,10 +40,10 @@
   h2 {
     background-color: var(--side-menu-collection-title-background-color);
     color: var(--side-menu-collection-title-text-color);
-    margin: 0;
-    padding: 16px 18px 16px 16px;
     font-size: 1rem;
     font-weight: bold;
+    margin: 0;
+    padding: 16px 18px 16px 16px;
   }
 }
 

--- a/src/theme/_general.scss
+++ b/src/theme/_general.scss
@@ -1,32 +1,32 @@
 html.md {
-    --ion-default-font: var(--font-stack-app-base);
+  --ion-default-font: var(--font-stack-app-base);
 }
-  
+
 body {
-    background-color: var(--main-background-color, #f2f2f2);
-    font-size: 1rem;
-    -webkit-user-select: text;
-    user-select: text;
+  background-color: var(--main-background-color, #f2f2f2);
+  font-size: 1rem;
+  -webkit-user-select: text;
+  user-select: text;
 }
-  
+
 a {
-    color: var(--default-link-color);
+  color: var(--default-link-color);
 }
 
 .visuallyhidden {
-    display: none !important;
+  display: none !important;
 }
 
 .screen-reader-only {
-    border: 0;
-    clip: rect(1px 1px 1px 1px);
-    clip: rect(1px, 1px, 1px, 1px);
-    clip-path: inset(50%);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
+  border: 0;
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }


### PR DESCRIPTION
The target of the back link in the collection side menu has been changed to the content page, /content.

The icon of the back link has been changed to a chevron for a more consistent look in the menu.

In mobile mode, the side menu remains open after clicking the back link.